### PR TITLE
Week 20 Daily and Weekly Equipment Booking Limit Fixes, Fix Weekly Equipment Booking Algorithm, Fix Workshop Bugs, Legend UI Changes

### DIFF
--- a/app/components/ui/Dashboard/equipmentbookinggrid.tsx
+++ b/app/components/ui/Dashboard/equipmentbookinggrid.tsx
@@ -529,6 +529,179 @@ export default function EquipmentBookingGrid({
     {
       /* Sliding 7-day periods approach */
     }
+    // // Check sliding 7-day period limits - each day creates a new 7-day period
+    // if (!isAlreadySelected) {
+    //   // Helper function to create date from day and time
+    //   const createDateFromDayTime = (day: string, time: string): Date => {
+    //     const dayParts = day.split(" ");
+    //     const dayNumber = parseInt(dayParts[1], 10);
+    //     const [hour, minute] = time.split(":").map(Number);
+
+    //     const now = new Date();
+    //     const date = new Date(
+    //       now.getFullYear(),
+    //       now.getMonth(),
+    //       dayNumber,
+    //       hour,
+    //       minute
+    //     );
+
+    //     // Adjust month if day is in next month
+    //     if (dayNumber < now.getDate() && now.getDate() > 20) {
+    //       date.setMonth(date.getMonth() + 1);
+    //     }
+
+    //     return date;
+    //   };
+
+    //   // Get all unique dates from the grid
+    //   const allDays = Object.keys(slotsByDay);
+    //   const allGridDates: Date[] = [];
+
+    //   for (const day of allDays) {
+    //     const dayParts = day.split(" ");
+    //     const dayNumber = parseInt(dayParts[1], 10);
+    //     const now = new Date();
+    //     const date = new Date(
+    //       now.getFullYear(),
+    //       now.getMonth(),
+    //       dayNumber,
+    //       0,
+    //       0,
+    //       0,
+    //       0
+    //     );
+
+    //     // Adjust month if day is in next month
+    //     if (dayNumber < now.getDate() && now.getDate() > 20) {
+    //       date.setMonth(date.getMonth() + 1);
+    //     }
+
+    //     allGridDates.push(date);
+    //   }
+
+    //   // Sort dates and remove duplicates
+    //   const uniqueDates = Array.from(
+    //     new Set(allGridDates.map((d) => d.toDateString()))
+    //   )
+    //     .map((dateStr) => new Date(dateStr))
+    //     .sort((a, b) => a.getTime() - b.getTime());
+
+    //   // Check ALL possible 7-day periods that could contain this slot
+    //   // Each day can be the start of a 7-day period
+    //   // Get all dates that have actual bookings or selections
+    //   const datesWithBookings = new Set<string>();
+
+    //   // Add dates from existing bookings
+    //   for (const day of allDays) {
+    //     const daySlots = slotsByDay[day];
+    //     for (const time of Object.keys(daySlots)) {
+    //       const slot = daySlots[time];
+    //       if (slot?.bookedByMe) { // This checks ALL bookings by you even in the past
+    //         const slotDate = createDateFromDayTime(day, time);
+    //         const dateOnly = new Date(slotDate);
+    //         dateOnly.setHours(0, 0, 0, 0);
+    //         datesWithBookings.add(dateOnly.toDateString());
+    //       }
+    //     }
+    //   }
+
+    //   // Add dates from current selections
+    //   for (const s of selectedSlots) {
+    //     const [start] = s.split("|");
+    //     const slotDate = new Date(start);
+    //     const dateOnly = new Date(slotDate);
+    //     dateOnly.setHours(0, 0, 0, 0);
+    //     datesWithBookings.add(dateOnly.toDateString());
+    //   }
+
+    //   // Add the current slot date
+    //   const currentSlotDateOnly = new Date(startTime);
+    //   currentSlotDateOnly.setHours(0, 0, 0, 0);
+    //   datesWithBookings.add(currentSlotDateOnly.toDateString());
+
+    //   // Convert back to Date objects and sort
+    //   const relevantDates = Array.from(datesWithBookings)
+    //     .map((dateStr) => new Date(dateStr))
+    //     .sort((a, b) => a.getTime() - b.getTime());
+
+    //   // Check periods that start from any date that has bookings/selections
+    //   // and could contain the current slot
+    //   for (const periodStartDate of relevantDates) {
+    //     const periodStart = new Date(periodStartDate);
+    //     periodStart.setHours(0, 0, 0, 0);
+
+    //     const periodEnd = new Date(periodStart);
+    //     periodEnd.setDate(periodStart.getDate() + 7);
+    //     periodEnd.setHours(0, 0, 0, 0);
+
+    //     // Check if the current slot falls within this 7-day period
+    //     if (
+    //       currentSlotDateOnly >= periodStart &&
+    //       currentSlotDateOnly < periodEnd
+    //     ) {
+    //       let totalSlotsInPeriod = 0;
+
+    //       // Count existing booked slots in this 7-day period
+    //       for (const day of allDays) {
+    //         const daySlots = slotsByDay[day];
+    //         for (const time of Object.keys(daySlots)) {
+    //           const slot = daySlots[time];
+    //           if (slot?.bookedByMe) { // This checks ALL bookings by you even in the past
+    //             const slotDate = createDateFromDayTime(day, time);
+    //             const slotDateOnly = new Date(slotDate);
+    //             slotDateOnly.setHours(0, 0, 0, 0);
+
+    //             if (slotDateOnly >= periodStart && slotDateOnly < periodEnd) {
+    //               totalSlotsInPeriod++;
+    //             }
+    //           }
+    //         }
+    //       }
+
+    //       // Count current session selections in this 7-day period
+    //       for (const s of selectedSlots) {
+    //         const [start] = s.split("|");
+    //         const slotDate = new Date(start);
+    //         const slotDateOnly = new Date(slotDate);
+    //         slotDateOnly.setHours(0, 0, 0, 0);
+
+    //         if (slotDateOnly >= periodStart && slotDateOnly < periodEnd) {
+    //           totalSlotsInPeriod++;
+    //         }
+    //       }
+
+    //       // Check if adding this slot would exceed the limit for THIS period
+    //       if (totalSlotsInPeriod + 1 > maxSlotsPerWeek) {
+    //         const periodStartStr = periodStart.toLocaleDateString("en-US", {
+    //           month: "short",
+    //           day: "numeric",
+    //           year: "numeric",
+    //         });
+    //         const periodEndDate = new Date(
+    //           periodEnd.getTime() - 24 * 60 * 60 * 1000
+    //         ); // Get the last day of the period
+    //         const periodEndStr = periodEndDate.toLocaleDateString("en-US", {
+    //           month: "short",
+    //           day: "numeric",
+    //           year: "numeric",
+    //         });
+
+    //         const hoursLimit = (maxSlotsPerWeek * 30) / 60; // Convert slots to hours
+    //         setErrorMessage(
+    //           `You can only select up to ${hoursLimit} hours (${maxSlotsPerWeek} slots) within any 7-day period. Period ${periodStartStr} - ${periodEndStr} would have ${
+    //             totalSlotsInPeriod + 1
+    //           } slots if you add this selection.`
+    //         );
+    //         return;
+    //       }
+    //     }
+    //   }
+    // }
+
+    {
+      /* Sliding 7-day periods approach including dates starting a week before first visible day in grid*/
+    }
     // Check sliding 7-day period limits - each day creates a new 7-day period
     if (!isAlreadySelected) {
       // Helper function to create date from day and time
@@ -554,11 +727,12 @@ export default function EquipmentBookingGrid({
         return date;
       };
 
-      // Get all unique dates from the grid
-      const allDays = Object.keys(slotsByDay);
+      // Get all dates from the grid PLUS a week before the first visible date
+      const allDaysFromGrid = Object.keys(slotsByDay);
       const allGridDates: Date[] = [];
 
-      for (const day of allDays) {
+      // First, get all visible dates from the grid
+      for (const day of allDaysFromGrid) {
         const dayParts = day.split(" ");
         const dayNumber = parseInt(dayParts[1], 10);
         const now = new Date();
@@ -580,6 +754,21 @@ export default function EquipmentBookingGrid({
         allGridDates.push(date);
       }
 
+      // Find the first visible date
+      const sortedGridDates = allGridDates.sort(
+        (a, b) => a.getTime() - b.getTime()
+      );
+      const firstVisibleDate = sortedGridDates[0];
+
+      // Add 7 days before the first visible date to capture previous bookings
+      if (firstVisibleDate) {
+        for (let i = 1; i <= 7; i++) {
+          const earlierDate = new Date(firstVisibleDate);
+          earlierDate.setDate(firstVisibleDate.getDate() - i);
+          allGridDates.push(earlierDate);
+        }
+      }
+
       // Sort dates and remove duplicates
       const uniqueDates = Array.from(
         new Set(allGridDates.map((d) => d.toDateString()))
@@ -587,17 +776,21 @@ export default function EquipmentBookingGrid({
         .map((dateStr) => new Date(dateStr))
         .sort((a, b) => a.getTime() - b.getTime());
 
+      // Update allDays to include the expanded date range for booking checks
+      const allDays = [...allDaysFromGrid]; // Keep original grid days for slot checking
+
       // Check ALL possible 7-day periods that could contain this slot
       // Each day can be the start of a 7-day period
       // Get all dates that have actual bookings or selections
       const datesWithBookings = new Set<string>();
 
-      // Add dates from existing bookings
-      for (const day of allDays) {
+      // Add dates from existing bookings (check both visible grid and expanded date range)
+      for (const day of allDaysFromGrid) {
         const daySlots = slotsByDay[day];
         for (const time of Object.keys(daySlots)) {
           const slot = daySlots[time];
-          if (slot?.bookedByMe) { // This checks ALL bookings by you even in the past
+          if (slot?.bookedByMe) {
+            // This checks ALL bookings by you even in the past
             const slotDate = createDateFromDayTime(day, time);
             const dateOnly = new Date(slotDate);
             dateOnly.setHours(0, 0, 0, 0);
@@ -642,12 +835,13 @@ export default function EquipmentBookingGrid({
         ) {
           let totalSlotsInPeriod = 0;
 
-          // Count existing booked slots in this 7-day period
-          for (const day of allDays) {
+          // Count existing booked slots in this 7-day period (check all visible days)
+          for (const day of allDaysFromGrid) {
             const daySlots = slotsByDay[day];
             for (const time of Object.keys(daySlots)) {
               const slot = daySlots[time];
-              if (slot?.bookedByMe) { // This checks ALL bookings by you even in the past
+              if (slot?.bookedByMe) {
+                // This checks ALL bookings by you even in the past
                 const slotDate = createDateFromDayTime(day, time);
                 const slotDateOnly = new Date(slotDate);
                 slotDateOnly.setHours(0, 0, 0, 0);

--- a/app/components/ui/Dashboard/equipmentbookinggrid.tsx
+++ b/app/components/ui/Dashboard/equipmentbookinggrid.tsx
@@ -1201,7 +1201,8 @@ export default function EquipmentBookingGrid({
                         !isAnyRestriction &&
                         !isPlannedClosure && (
                           <div className="hidden group-hover:block absolute z-20 -mt-10 left-1/2 transform -translate-x-1/2 px-2 py-1 bg-green-100 border border-green-200 rounded text-green-700 text-xs whitespace-nowrap shadow-lg">
-                            Reserved for this workshop
+                            {/* Reserved for this workshop */}
+                            Current Workshop Time
                           </div>
                         )}
                       {isCurrentWorkshopEditingSlot &&
@@ -1209,7 +1210,8 @@ export default function EquipmentBookingGrid({
                         !isAnyRestriction &&
                         !isPlannedClosure && (
                           <div className="hidden group-hover:block absolute z-20 -mt-10 left-1/2 transform -translate-x-1/2 px-2 py-1 bg-yellow-100 border border-yellow-200 rounded text-yellow-700 text-xs whitespace-nowrap shadow-lg">
-                            Currently editing this workshop date
+                            {/* Currently editing this workshop date */}
+                            Old Workshop Time
                           </div>
                         )}
                       {isOtherWorkshopSlot &&
@@ -1225,7 +1227,11 @@ export default function EquipmentBookingGrid({
                         !isAnyRestriction &&
                         !isPlannedClosure &&
                         !(isWorkshopSlot || slot?.reservedForWorkshop) && (
-                          <div className="hidden group-hover:block absolute z-20 -mt-10 left-1/2 transform -translate-x-1/2 px-2 py-1 bg-blue-100 border border-blue-200 rounded text-blue-700 text-xs whitespace-nowrap shadow-lg">
+                          <div className={`hidden group-hover:block absolute z-20 -mt-10 left-1/2 transform -translate-x-1/2 px-2 py-1 rounded text-xs whitespace-nowrap shadow-lg ${
+                            slot?.bookedByMe 
+                              ? "bg-blue-100 border border-blue-200 text-blue-700"
+                              : "bg-red-100 border border-red-200 text-red-700"
+                          }`}>
                             {slot?.bookedByMe
                               ? "Booked by you"
                               : "Booked by others"}
@@ -1377,12 +1383,16 @@ export default function EquipmentBookingGrid({
             <span>Unavailable</span>
           </div>
           <div className="flex items-center gap-0.5">
-            <div className="w-3 h-3 bg-green-500 border border-gray-300" />
-            <span>Available</span>
-          </div>
-          <div className="flex items-center gap-0.5">
             <div className="w-3 h-3 bg-white border border-gray-300" />
             <span>Unselected</span>
+          </div>
+          <div className="flex items-center gap-0.5">
+            <div className="w-3 h-3 bg-green-500 border border-gray-300" />
+            <span>{currentWorkshopOccurrences && currentWorkshopOccurrences.length > 0 ? "Current Workshop Time(s)" : "Available"}</span>
+          </div>
+          <div className="flex items-center gap-0.5">
+            <div className="w-3 h-3 bg-yellow-400 border border-gray-300" />
+             <span>{currentWorkshopOccurrences && currentWorkshopOccurrences.length > 0 ? "Previous Workshop Time(s)" : "Being Edited"}</span>
           </div>
           <div className="flex items-center gap-0.5">
             <div className="w-3 h-3 bg-blue-400 border border-gray-300" />
@@ -1395,10 +1405,6 @@ export default function EquipmentBookingGrid({
           <div className="flex items-center gap-0.5">
             <div className="w-3 h-3 bg-purple-400 border border-gray-300" />
             <span>Reserved for Workshop</span>
-          </div>
-          <div className="flex items-center gap-0.5">
-            <div className="w-3 h-3 bg-yellow-400 border border-gray-300" />
-            <span>Being Edited</span>
           </div>
           {(level3Restrictions || level4Restrictions) && (
             <div className="flex items-center gap-0.5">

--- a/app/routes/dashboard/addworkshop.tsx
+++ b/app/routes/dashboard/addworkshop.tsx
@@ -801,6 +801,13 @@ export default function AddWorkshop() {
   ) {
     const localDate = parseDateTimeAsLocal(value);
     const updatedOccurrences = [...occurrences];
+
+    // AUTO-SET END DATE: If updating start date and it's valid, automatically set end date to 2 hours later
+    if (field === "startDate" && !isNaN(localDate.getTime())) {
+      const endDate = new Date(localDate.getTime() + (2 * 60 * 60 * 1000)); // Add 2 hours
+      updatedOccurrences[index].endDate = endDate;
+    }
+
     updatedOccurrences[index][field] = localDate;
     // Re-sort the list after updating.
     updatedOccurrences.sort(

--- a/app/routes/dashboard/adminsettings.tsx
+++ b/app/routes/dashboard/adminsettings.tsx
@@ -505,6 +505,13 @@ export default function AdminSettings() {
     message: "",
   });
 
+  const [weeklyLimitError, setWeeklyLimitError] = useState<string>("");
+
+  const [dailyFormBeingEdited, setDailyFormBeingEdited] =
+    useState<boolean>(false);
+  const [weeklyFormBeingEdited, setWeeklyFormBeingEdited] =
+    useState<boolean>(false);
+
   // Define columns for the ShadTable
   type UserRow = (typeof users)[number];
   const columns: ColumnDefinition<UserRow>[] = [
@@ -761,6 +768,45 @@ export default function AdminSettings() {
     }
     return options;
   }, []);
+
+  const validateLimits = (): boolean => {
+    // Convert daily limit to slots (30-minute slots)
+    const dailyInMinutes =
+      maxEquipmentSlotsPerDay.unit === "hours"
+        ? maxEquipmentSlotsPerDay.value * 60
+        : maxEquipmentSlotsPerDay.value;
+    const dailyInSlots = dailyInMinutes / 30;
+
+    // Weekly is always in slots
+    const weeklyInSlots = maxEquipmentSlotsPerWeek.value;
+
+    // CHANGE BACK TO JUST < (weekly can equal daily, but not be less)
+    if (weeklyInSlots < dailyInSlots) {
+      setWeeklyLimitError(
+        `Weekly limit (${weeklyInSlots} slots) cannot be less than daily limit (${dailyInSlots} slots)`
+      );
+      return false;
+    }
+
+    setWeeklyLimitError("");
+    return true;
+  };
+
+  // Keep the old function name for compatibility but call the new one
+  const validateWeeklyLimit = (
+    weeklyValue: number,
+    weeklyUnit: string
+  ): boolean => {
+    return validateLimits();
+  };
+
+  React.useEffect(() => {
+    validateLimits();
+  }, [
+    maxEquipmentSlotsPerDay.value,
+    maxEquipmentSlotsPerDay.unit,
+    maxEquipmentSlotsPerWeek.value,
+  ]);
 
   const level3TimeRange = calculateLevel3TimeRange();
 
@@ -1297,6 +1343,28 @@ export default function AdminSettings() {
                       </CardDescription>
                     </CardHeader>
                     <CardContent className="space-y-4">
+                      {/* ADD BLOCKING UI WHEN WEEKLY IS BEING EDITED */}
+                      {weeklyFormBeingEdited && (
+                        <Alert>
+                          <AlertCircle className="h-4 w-4" />
+                          <AlertDescription>
+                            Cannot edit daily limits while weekly limits are
+                            being modified. Please save or cancel your weekly
+                            changes first.
+                          </AlertDescription>
+                        </Alert>
+                      )}
+
+                      {/* ADD ERROR DISPLAY FOR DAILY FORM TOO */}
+                      {weeklyLimitError && (
+                        <Alert variant="destructive">
+                          <AlertCircle className="h-4 w-4" />
+                          <AlertDescription>
+                            {weeklyLimitError}
+                          </AlertDescription>
+                        </Alert>
+                      )}
+
                       <div className="space-y-2">
                         <Label htmlFor="maxEquipmentSlotsPerDay">
                           Maximum Equipment Booking Time Per Day
@@ -1306,6 +1374,9 @@ export default function AdminSettings() {
                             id="maxEquipmentSlotsPerDay"
                             type="number"
                             value={maxEquipmentSlotsPerDay.value}
+                            disabled={weeklyFormBeingEdited}
+                            onFocus={() => setDailyFormBeingEdited(true)}
+                            onBlur={() => setDailyFormBeingEdited(false)}
                             onChange={(e) => {
                               const inputValue = parseInt(e.target.value) || 30;
                               let validValue = inputValue;
@@ -1327,10 +1398,28 @@ export default function AdminSettings() {
                                 );
                               }
 
-                              setMaxEquipmentSlotsPerDay((prev) => ({
-                                ...prev,
+                              const newDailyState = {
+                                ...maxEquipmentSlotsPerDay,
                                 value: validValue,
-                              }));
+                              };
+                              setMaxEquipmentSlotsPerDay(newDailyState);
+
+                              // Validate with the new values immediately
+                              const dailyInMinutes =
+                                newDailyState.unit === "hours"
+                                  ? newDailyState.value * 60
+                                  : newDailyState.value;
+                              const dailyInSlots = dailyInMinutes / 30;
+                              const weeklyInSlots =
+                                maxEquipmentSlotsPerWeek.value;
+
+                              if (weeklyInSlots < dailyInSlots) {
+                                setWeeklyLimitError(
+                                  `Weekly limit (${weeklyInSlots} slots) cannot be less than daily limit (${dailyInSlots} slots)`
+                                );
+                              } else {
+                                setWeeklyLimitError("");
+                              }
                             }}
                             min={
                               maxEquipmentSlotsPerDay.unit === "hours"
@@ -1347,10 +1436,15 @@ export default function AdminSettings() {
                                 ? "1"
                                 : "30"
                             }
-                            className="w-24"
+                            className={`w-24 ${
+                              weeklyLimitError ? "border-red-500" : ""
+                            } ${weeklyFormBeingEdited ? "opacity-50" : ""}`}
                           />
                           <select
                             value={maxEquipmentSlotsPerDay.unit}
+                            disabled={weeklyFormBeingEdited}
+                            onFocus={() => setDailyFormBeingEdited(true)}
+                            onBlur={() => setDailyFormBeingEdited(false)}
                             onChange={(e) => {
                               const newUnit = e.target.value;
                               const currentMinutes =
@@ -1358,21 +1452,40 @@ export default function AdminSettings() {
                                   ? maxEquipmentSlotsPerDay.value * 60
                                   : maxEquipmentSlotsPerDay.value;
 
-                              setMaxEquipmentSlotsPerDay({
+                              const newValue =
+                                newUnit === "hours"
+                                  ? Math.max(1, Math.floor(currentMinutes / 60))
+                                  : Math.max(
+                                      30,
+                                      Math.round(currentMinutes / 30) * 30
+                                    );
+
+                              const newDailyState = {
                                 unit: newUnit,
-                                value:
-                                  newUnit === "hours"
-                                    ? Math.max(
-                                        1,
-                                        Math.floor(currentMinutes / 60)
-                                      )
-                                    : Math.max(
-                                        30,
-                                        Math.round(currentMinutes / 30) * 30
-                                      ),
-                              });
+                                value: newValue,
+                              };
+                              setMaxEquipmentSlotsPerDay(newDailyState);
+
+                              // Validate with the new values immediately
+                              const dailyInMinutes =
+                                newDailyState.unit === "hours"
+                                  ? newDailyState.value * 60
+                                  : newDailyState.value;
+                              const dailyInSlots = dailyInMinutes / 30;
+                              const weeklyInSlots =
+                                maxEquipmentSlotsPerWeek.value;
+
+                              if (weeklyInSlots < dailyInSlots) {
+                                setWeeklyLimitError(
+                                  `Weekly limit (${weeklyInSlots} slots) cannot be less than daily limit (${dailyInSlots} slots)`
+                                );
+                              } else {
+                                setWeeklyLimitError("");
+                              }
                             }}
-                            className="border rounded px-2 py-1 text-sm w-20"
+                            className={`border rounded px-2 py-1 text-sm w-20 ${
+                              weeklyFormBeingEdited ? "opacity-50" : ""
+                            }`}
                           >
                             <option value="hours">Hours</option>
                             <option value="minutes">Minutes</option>
@@ -1393,16 +1506,17 @@ export default function AdminSettings() {
                     <CardFooter>
                       <Button
                         type="submit"
-                        className="bg-yellow-500 hover:bg-yellow-600 text-white"
+                        disabled={weeklyFormBeingEdited || !!weeklyLimitError}
+                        className="bg-yellow-500 hover:bg-yellow-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <Save className="h-4 w-4 mr-2" />
-                        Save Booking Limits
+                        Save Daily Limits
                       </Button>
                     </CardFooter>
                   </Card>
                 </Form>
 
-                 {/* Max Equipment Slots Per Week Form */}
+                {/* Max Equipment Slots Per Week Form */}
                 <Form method="post" className="space-y-6 mb-8">
                   <input
                     type="hidden"
@@ -1417,20 +1531,43 @@ export default function AdminSettings() {
                   <input
                     type="hidden"
                     name="maxEquipmentSlotsPerWeek"
-                    value={
-                      maxEquipmentSlotsPerWeek.unit === "hours"
-                        ? maxEquipmentSlotsPerWeek.value * 2 // Convert hours to 30-min slots
-                        : maxEquipmentSlotsPerWeek.value
-                    }
+                    // value={
+                    //   maxEquipmentSlotsPerWeek.unit === "hours"
+                    //     ? maxEquipmentSlotsPerWeek.value * 2 // Convert hours to 30-min slots
+                    //     : maxEquipmentSlotsPerWeek.value
+                    // }
+                    value={maxEquipmentSlotsPerWeek.value}
                   />
                   <Card>
                     <CardHeader>
                       <CardTitle>Weekly Equipment Booking Limits</CardTitle>
                       <CardDescription>
-                        Set the maximum number of slots a user can book equipment per week (7-day period)
+                        Set the maximum number of slots a user can book
+                        equipment per week (7-day period)
                       </CardDescription>
                     </CardHeader>
                     <CardContent className="space-y-4">
+                      {/* ADD BLOCKING UI WHEN DAILY IS BEING EDITED */}
+                      {dailyFormBeingEdited && (
+                        <Alert>
+                          <AlertCircle className="h-4 w-4" />
+                          <AlertDescription>
+                            Cannot edit weekly limits while daily limits are
+                            being modified. Please save or cancel your daily
+                            changes first.
+                          </AlertDescription>
+                        </Alert>
+                      )}
+
+                      {weeklyLimitError && (
+                        <Alert variant="destructive">
+                          <AlertCircle className="h-4 w-4" />
+                          <AlertDescription>
+                            {weeklyLimitError}
+                          </AlertDescription>
+                        </Alert>
+                      )}
+
                       <div className="space-y-2">
                         <Label htmlFor="maxEquipmentSlotsPerWeek">
                           Maximum Equipment Booking Slots Per Week
@@ -1440,83 +1577,73 @@ export default function AdminSettings() {
                             id="maxEquipmentSlotsPerWeek"
                             type="number"
                             value={maxEquipmentSlotsPerWeek.value}
+                            disabled={dailyFormBeingEdited}
+                            onFocus={() => setWeeklyFormBeingEdited(true)}
+                            onBlur={() => setWeeklyFormBeingEdited(false)}
                             onChange={(e) => {
                               const inputValue = parseInt(e.target.value) || 1;
-                              let validValue = inputValue;
-
-                              if (maxEquipmentSlotsPerWeek.unit === "hours") {
-                                // For hours: minimum 0.5, maximum 84 (3.5 days)
-                                validValue = Math.max(
-                                  0.5,
-                                  Math.min(84, inputValue)
-                                );
-                              } else {
-                                // For slots: minimum 1, maximum 168 (7 days * 24 hours * 2 slots per hour)
-                                validValue = Math.max(
-                                  1,
-                                  Math.min(168, inputValue)
-                                );
-                              }
+                              // For slots: minimum 1, maximum 168 (7 days * 24 hours * 2 slots per hour)
+                              const validValue = Math.max(
+                                1,
+                                Math.min(168, inputValue)
+                              );
 
                               setMaxEquipmentSlotsPerWeek((prev) => ({
                                 ...prev,
                                 value: validValue,
                               }));
-                            }}
-                            min={
-                              maxEquipmentSlotsPerWeek.unit === "hours"
-                                ? "0.5"
-                                : "1"
-                            }
-                            max={
-                              maxEquipmentSlotsPerWeek.unit === "hours"
-                                ? "84"
-                                : "168"
-                            }
-                            step={
-                              maxEquipmentSlotsPerWeek.unit === "hours"
-                                ? "0.5"
-                                : "1"
-                            }
-                            className="w-24"
-                          />
-                          <select
-                            value={maxEquipmentSlotsPerWeek.unit}
-                            onChange={(e) => {
-                              const newUnit = e.target.value;
-                              const currentSlots = maxEquipmentSlotsPerWeek.value;
 
-                              setMaxEquipmentSlotsPerWeek({
-                                unit: newUnit,
-                                value:
-                                  newUnit === "hours"
-                                    ? Math.max(0.5, currentSlots / 2) // Convert slots to hours
-                                    : Math.max(1, currentSlots * 2), // Convert hours to slots
-                              });
+                              // Validate with the new weekly value immediately
+                              const dailyInMinutes =
+                                maxEquipmentSlotsPerDay.unit === "hours"
+                                  ? maxEquipmentSlotsPerDay.value * 60
+                                  : maxEquipmentSlotsPerDay.value;
+                              const dailyInSlots = dailyInMinutes / 30;
+
+                              if (validValue < dailyInSlots) {
+                                setWeeklyLimitError(
+                                  `Weekly limit (${validValue} slots) cannot be less than daily limit (${dailyInSlots} slots)`
+                                );
+                              } else {
+                                setWeeklyLimitError("");
+                              }
                             }}
-                            className="border rounded px-2 py-1 text-sm w-20"
+                            min="1"
+                            max="168"
+                            step="1"
+                            className={`w-24 ${
+                              weeklyLimitError ? "border-red-500" : ""
+                            } ${dailyFormBeingEdited ? "opacity-50" : ""}`}
+                          />
+                          <span
+                            className={`text-sm text-gray-600 w-16 ${
+                              dailyFormBeingEdited ? "opacity-50" : ""
+                            }`}
                           >
-                            <option value="slots">Slots</option>
-                            <option value="hours">Hours</option>
-                          </select>
+                            Slots
+                          </span>
                         </div>
                         <p className="text-sm text-gray-500">
-                          Maximum number of 30-minute slots a user can book per 7-day period. 
-                          Slots: 1-168 slots (each slot = 30 minutes). Hours: 0.5-84 hours. 
-                          Current setting:{" "}
-                          {maxEquipmentSlotsPerWeek.unit === "hours"
-                            ? maxEquipmentSlotsPerWeek.value * 2
-                            : maxEquipmentSlotsPerWeek.value}{" "}
-                          slots ({maxEquipmentSlotsPerWeek.unit === "hours"
-                            ? maxEquipmentSlotsPerWeek.value
-                            : maxEquipmentSlotsPerWeek.value / 2} hours)
+                          Maximum number of 30-minute slots a user can book per
+                          7-day period. Range: 1-168 slots (each slot = 30
+                          minutes). Current setting:{" "}
+                          {maxEquipmentSlotsPerWeek.value} slots (
+                          {maxEquipmentSlotsPerWeek.value / 2} hours). Must be
+                          at least{" "}
+                          {Math.ceil(
+                            (maxEquipmentSlotsPerDay.unit === "hours"
+                              ? maxEquipmentSlotsPerDay.value * 60
+                              : maxEquipmentSlotsPerDay.value) / 30
+                          )}{" "}
+                          slots (daily limit).
                         </p>
                       </div>
                     </CardContent>
                     <CardFooter>
                       <Button
                         type="submit"
-                        className="bg-yellow-500 hover:bg-yellow-600 text-white"
+                        disabled={dailyFormBeingEdited || !!weeklyLimitError}
+                        className="bg-yellow-500 hover:bg-yellow-600 text-white disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <Save className="h-4 w-4 mr-2" />
                         Save Weekly Limits

--- a/app/routes/dashboard/editworkshop.tsx
+++ b/app/routes/dashboard/editworkshop.tsx
@@ -733,7 +733,9 @@ export default function EditWorkshop() {
         connectId: occ.connectId,
         offerId: occ.offerId, // Add this line
       };
-    }) || [];
+    })
+    // SORT INITIAL OCCURRENCES: Sort by startDate when first loading
+    .sort((a, b) => a.startDate.getTime() - b.startDate.getTime()) || [];
 
   const defaultContinuation =
     initialOccurrences.some((occ) => occ.connectId != null) || false;

--- a/app/routes/dashboard/editworkshop.tsx
+++ b/app/routes/dashboard/editworkshop.tsx
@@ -1166,7 +1166,10 @@ export default function EditWorkshop() {
       setFormSubmitting(true);
 
       // Use DOM to submit the form
-      document.forms[0].submit();
+      // document.forms[0].submit();
+
+      const formElement = e.currentTarget as HTMLFormElement;
+      formElement.submit();
     } catch (error) {
       console.error("Error in form submission:", error);
       // Ensure form submits even if there's an error in our checks
@@ -2291,16 +2294,19 @@ export default function EditWorkshop() {
                             "User confirmed to proceed with past dates"
                           );
                           setFormSubmitting(true);
-                          // Use setTimeout to ensure React state updates before form submission
+                          setIsConfirmDialogOpen(false);
+                          // FIXED: Use setTimeout to ensure dialog closes and then submit
                           setTimeout(() => {
                             const formElement = document.querySelector(
                               "form"
                             ) as HTMLFormElement;
                             if (formElement) {
                               console.log("Submitting form after confirmation");
-                              formElement.submit();
+                              // Create and dispatch a submit event to trigger the action
+                              const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+                              formElement.dispatchEvent(submitEvent);
                             }
-                          }, 50);
+                          }, 100);
                         }}
                       >
                         Proceed Anyway

--- a/app/routes/dashboard/editworkshop.tsx
+++ b/app/routes/dashboard/editworkshop.tsx
@@ -920,6 +920,12 @@ export default function EditWorkshop() {
     // Update the chosen field
     updatedOccurrences[index][field] = localDate;
 
+    // AUTO-SET END DATE: If updating start date and it's valid, automatically set end date to 2 hours later
+    if (field === "startDate" && !isNaN(localDate.getTime())) {
+      const endDate = new Date(localDate.getTime() + (2 * 60 * 60 * 1000)); // Add 2 hours
+      updatedOccurrences[index].endDate = endDate;
+    }
+
     // If it's not already cancelled, compute a new status based on the start date.
     if (updatedOccurrences[index].status !== "cancelled") {
       const start = updatedOccurrences[index].startDate;

--- a/seed.ts
+++ b/seed.ts
@@ -183,8 +183,8 @@ async function main() {
     },
     {
       workshopId: 2, // Pottery
-      startDate: new Date("2025-06-10T14:00:00Z"),
-      endDate: new Date("2025-06-10T16:00:00Z"),
+      startDate: new Date("2025-07-10T14:00:00Z"),
+      endDate: new Date("2025-07-10T16:00:00Z"),
     },
     {
       workshopId: 3, // Knitting


### PR DESCRIPTION
- set weekly to be as much as the daily in equipment settings [DONE]
- just hide the hours in the weekly thing [DONE]
- edge case (Dates outside grid for sliding window) [DONE]
- workshop dates (3rd box default to same day, 4th box default to 2 hours from selected)
- sort the dates in editworkshop [DONE]
- change legend (green current timing, yellow previous/old timing; group these together)
- fixed bug related to nothing showing anything booked when it was as testuser2@gmail.com [DONE]
- fix the update workshop bug [DONE]