### PR TITLE
feat: email notifications for cancellations and membership reminders

### DIFF
--- a/app/utils/email.server.ts
+++ b/app/utils/email.server.ts
@@ -8,33 +8,118 @@ dotenv.config();
 const mailgun = new Mailgun(formData);
 const mg = mailgun.client({
   username: "api",
-  key: process.env.MAILGUN_API_KEY as string
+  key: process.env.MAILGUN_API_KEY as string,
 });
+
+const MAILGUN_DOMAIN: string | undefined = process.env.MAILGUN_DOMAIN;
+const MAILGUN_FROM_EMAIL: string | undefined = process.env.MAILGUN_FROM_EMAIL;
+
+function assertEmailEnvConfigured(): void {
+  if (!process.env.MAILGUN_API_KEY) {
+    throw new Error("MAILGUN_API_KEY is not configured");
+  }
+  if (!MAILGUN_DOMAIN) {
+    throw new Error("MAILGUN_DOMAIN is not configured");
+  }
+  if (!MAILGUN_FROM_EMAIL) {
+    throw new Error("MAILGUN_FROM_EMAIL is not configured");
+  }
+}
+
+async function sendMail({
+  to,
+  subject,
+  text,
+  html,
+}: {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+}): Promise<void> {
+  assertEmailEnvConfigured();
+  const domain = MAILGUN_DOMAIN as string;
+  const from = `Makerspace YK <${MAILGUN_FROM_EMAIL as string}>`;
+
+  await mg.messages.create(domain, {
+    from,
+    to,
+    subject,
+    text,
+    ...(html ? { html } : {}),
+  });
+}
 
 async function sendPasswordResetEmail(
   userEmail: string,
   resetLink: string,
-) {
-  const emailData = {
-    from: `Makerspace YK <info@makerspaceyk.com>`,
+): Promise<void> {
+  await sendMail({
     to: userEmail,
     subject: "Password Reset Request",
     text: `Please use the following link to reset your password. The following link is valid for next 1 hour.\n${resetLink}`,
-  };
-
-  try {
-    await mg.messages.create("makerspaceyk.com", emailData);
-  } catch (error) {
-    throw new Error("Failed to send confirmation email.");
-  }
+  });
 }
 
 function generateResetToken(email: string): string {
   return jwt.sign({ email }, process.env.JWT_SECRET as string, { expiresIn: '1h' });
 }
 
-export async function sendResetEmail(email: string) {
+export async function sendResetEmail(email: string): Promise<void> {
   const token = generateResetToken(email);
-  const resetLink = `${process.env.BASE_URL}/passwordReset?token=${token}`;
+  const baseUrl = process.env.BASE_URL ?? "";
+  const resetLink = `${baseUrl}/passwordReset?token=${token}`;
   await sendPasswordResetEmail(email, resetLink);
+}
+
+export async function sendWorkshopCancellationEmail(params: {
+  userEmail: string;
+  workshopName: string;
+  startDate: Date;
+  endDate: Date;
+}): Promise<void> {
+  const { userEmail, workshopName, startDate, endDate } = params;
+  const start = new Date(startDate).toLocaleString();
+  const end = new Date(endDate).toLocaleString();
+  const text = `Your registration for "${workshopName}" has been cancelled.\nSession: ${start} - ${end}.\nIf this was a mistake, please re‑register from your dashboard.`;
+  await sendMail({
+    to: userEmail,
+    subject: `Cancellation confirmed: ${workshopName}`,
+    text,
+  });
+}
+
+export async function sendEquipmentCancellationEmail(params: {
+  userEmail: string;
+  equipmentName: string;
+  startTime: Date;
+  endTime: Date;
+}): Promise<void> {
+  const { userEmail, equipmentName, startTime, endTime } = params;
+  const start = new Date(startTime).toLocaleString();
+  const end = new Date(endTime).toLocaleString();
+  const text = `Your booking for "${equipmentName}" has been cancelled.\nTime: ${start} - ${end}.`;
+  await sendMail({
+    to: userEmail,
+    subject: `Equipment booking cancelled: ${equipmentName}`,
+    text,
+  });
+}
+
+export async function sendMembershipPaymentReminderEmail(params: {
+  userEmail: string;
+  planTitle: string;
+  nextPaymentDate: Date;
+  amountDue: number;
+  gstPercentage?: number;
+}): Promise<void> {
+  const { userEmail, planTitle, nextPaymentDate, amountDue, gstPercentage } = params;
+  const when = new Date(nextPaymentDate).toLocaleString();
+  const gstLine = typeof gstPercentage === "number" ? ` (includes ${gstPercentage}% GST)` : "";
+  const text = `Reminder: Your membership plan "${planTitle}" will be charged on ${when}.\nAmount due: $${amountDue.toFixed(2)}${gstLine}.\nIf you need to update your payment method, please visit your account settings.`;
+  await sendMail({
+    to: userEmail,
+    subject: `Membership payment reminder: ${planTitle}`,
+    text,
+  });
 }


### PR DESCRIPTION
## Overview
Adds Mailgun-powered emails for:
- Workshop registration cancellation
- Equipment booking cancellation
- Membership payment reminder (rolling 24-hour window)

Centralizes email sending in a single utility and validates Mailgun environment configuration.

## Changes
- Centralized Mailgun email helper with env validation and helpers:
  - `sendWorkshopCancellationEmail`
  - `sendEquipmentCancellationEmail`
  - `sendMembershipPaymentReminderEmail`
- Workshop cancellation flow sends a confirmation email after successful cancellation
- Equipment cancellation flow sends a confirmation email after successful cancellation
- Membership cron:
  - Sends reminders when `nextPaymentDate` is within the next 24 hours (rolling window)
  - Current interval: as configured in `app/models/membership.server.ts`

## How to Test
- Workshop cancellation email
  1. Register for a workshop
  2. Cancel on `Workshop Details` page
  3. Check inbox and Mailgun logs

- Equipment cancellation email
  1. Book an equipment slot
  2. Cancel on `Dashboard → My Equipments`
  3. Check inbox and Mailgun logs

- Membership reminder email
  1. Ensure a user has `UserMembership.status = active`
  2. Set `nextPaymentDate` within the next 24 hours
  3. Keep server running; cron will scan on its configured schedule (set interval to every minute for testing)
  4. Check inbox and Mailgun logs

## Operational Notes
- Missing Mailgun env vars will throw fast, preventing silent failures.