### PR TITLE
fix: Resubscribe Functionality for Upgraded Subscriptions

### DIFF
--- a/app/models/membership.server.ts
+++ b/app/models/membership.server.ts
@@ -191,10 +191,17 @@ export async function registerMembershipSubscription(
     if (!cancelledMembership) {
       throw new Error("No cancelled membership found for resubscription");
     }
-    // Update the cancelled record to active.
+    // Update the cancelled record to active and set new next payment date
+    const now = new Date();
+    const newNextPaymentDate = new Date(now);
+    newNextPaymentDate.setMonth(newNextPaymentDate.getMonth() + 1);
+
     const subscription = await db.userMembership.update({
       where: { id: cancelledMembership.id },
-      data: { status: "active" },
+      data: {
+        status: "active",
+        nextPaymentDate: newNextPaymentDate,
+      },
     });
     return subscription;
   }

--- a/app/routes/dashboard/memberships.tsx
+++ b/app/routes/dashboard/memberships.tsx
@@ -22,6 +22,7 @@ import GuestAppSidebar from "~/components/ui/Dashboard/Guestsidebar";
 type MembershipStatus = "active" | "cancelled" | "inactive";
 
 type UserMembershipData = {
+  id: number;
   membershipPlanId: number;
   status: MembershipStatus;
   nextPaymentDate?: Date;
@@ -67,6 +68,7 @@ export async function loader({ request }: { request: Request }) {
       }
 
       return {
+        id: m.id,
         membershipPlanId: m.membershipPlanId,
         status,
         nextPaymentDate: m.nextPaymentDate,
@@ -276,6 +278,7 @@ export default function MembershipPage() {
                   hasCancelledSubscription={hasCancelledSubscription}
                   highestActivePrice={highestActivePrice}
                   nextPaymentDate={membership?.nextPaymentDate}
+                  membershipRecordId={membership?.id}
                   roleUser={roleUser}
                   isCurrentlyActivePlan={membershipStatus === "active"}
                 />


### PR DESCRIPTION
## Problem
Users cannot resubscribe to upgraded subscription plans after cancellation. The resubscribe functionality works for regular memberships but fails for upgraded subscriptions.

## Root Cause
1. Missing `membershipRecordId` in frontend data mapping
2. Missing `nextPaymentDate` updates on reactivation
3. Admin permission checks blocking resubscription attempts

## Solution
Comprehensive fix for resubscribe functionality across the entire flow:

### Frontend Changes
- **memberships.tsx**: Add `id` field to membership data mapping and pass `membershipRecordId` prop
- **payment.tsx**: Extract `membershipRecordId` from query parameters, convert to number, bypass admin checks for resubscription

### Backend Changes  
- **membership.server.ts**: Update `nextPaymentDate` when reactivating cancelled memberships

## Testing
Subscribe -> Upgrade -> Cancel -> Resubscribe