### PR TITLE
fix: Filter prerequisites to active orientations in admin workshop creation

### DIFF
--- a/app/routes/dashboard/addworkshop.tsx
+++ b/app/routes/dashboard/addworkshop.tsx
@@ -724,7 +724,12 @@ export default function AddWorkshop() {
     equipmentVisibilityDays,
     roleUser,
   } = useLoaderData() as {
-    workshops: { id: number; name: string; type: string }[];
+    workshops: {
+      id: number;
+      name: string;
+      type: string;
+      occurrences: { status: string }[];
+    }[];
     equipments: {
       id: number;
       name: string;
@@ -1759,9 +1764,11 @@ export default function AddWorkshop() {
                     onRemove={removePrerequisite}
                     error={actionData?.errors?.prerequisites}
                     placeholder="Select prerequisites..."
-                    helperText="Select workshops of type Orientation that must be completed before enrolling."
+                    helperText="Select active workshops of type Orientation that must be completed before enrolling."
                     filterFn={(item) =>
-                      item.type.toLowerCase() === "orientation"
+                      item.type.toLowerCase() === "orientation" &&
+                      Array.isArray(item.occurrences) &&
+                      item.occurrences.some((o) => o.status === "active")
                     }
                   />
                 ) : (


### PR DESCRIPTION
Restricts prerequisite selection on the Add Workshop page to orientation workshops with at least one active occurrence.

**Changes:**
- Updated `MultiSelectField` filter in `addworkshop.tsx` to include only orientation workshops with active occurrences
- Updated helper text to reflect the restriction
- Adjusted TypeScript types to include `occurrences` in the workshop interface

**Files Modified:**
- `app/routes/dashboard/addworkshop.tsx`

**Impact:**
- Admins can only select active orientations as prerequisites
- Prevents selecting orientations with no upcoming sessions
- No changes to user-facing views