### PR TITLE
feat: Add Coupon Code Support to Stripe Checkout

### DIFF
--- a/app/components/ui/Dashboard/quickcheckout.tsx
+++ b/app/components/ui/Dashboard/quickcheckout.tsx
@@ -5,7 +5,16 @@ import {
   AlertCircle,
   Loader2,
   Clock,
+  Tag,
+  Info,
 } from "lucide-react";
+import { Badge } from "../badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../tooltip";
 
 interface QuickCheckoutProps {
   userId: number;
@@ -160,8 +169,36 @@ export default function QuickCheckout({
             <CreditCard className="h-6 w-6 text-white" />
           </div>
         </div>
-        <div className="ml-4">
-          <h3 className="text-lg font-bold text-gray-900">Quick Checkout</h3>
+        <div className="ml-4 flex-1">
+          <div className="flex items-center gap-3 mb-1">
+            <h3 className="text-lg font-bold text-gray-900">Quick Checkout</h3>
+
+            {/* Coupon Notice Badge */}
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant="outline"
+                    className="bg-amber-50 border-amber-200 text-amber-700 hover:bg-amber-100 cursor-help flex items-center gap-1"
+                  >
+                    <Tag className="h-3 w-3" />
+                    <span className="text-xs">Coupon?</span>
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                  <div className="flex items-start gap-2">
+                    <Info className="h-4 w-4 text-blue-500 mt-0.5 flex-shrink-0" />
+                    <div>
+                      <p className="font-medium text-sm">Have a coupon code?</p>
+                      <p className="text-xs text-gray-300 mt-1">
+                        Use the "Proceed" button below to access Stripe checkout where you can enter your promotion code for discounts.
+                      </p>
+                    </div>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
           <p className="text-sm text-gray-600">
             Pay instantly with your saved card
           </p>

--- a/app/models/payment.server.ts
+++ b/app/models/payment.server.ts
@@ -660,6 +660,7 @@ export async function createCheckoutSession(request: Request) {
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ["card"],
       mode: "payment",
+      allow_promotion_codes: true,
       payment_intent_data: {
         setup_future_usage: "off_session",
       },
@@ -728,6 +729,7 @@ export async function createCheckoutSession(request: Request) {
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ["card"],
       mode: "payment",
+      allow_promotion_codes: true,
       line_items: [
         {
           price_data: {
@@ -801,6 +803,7 @@ export async function createCheckoutSession(request: Request) {
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ["card"],
       mode: "payment",
+      allow_promotion_codes: true,
       line_items: [
         {
           price_data: {
@@ -857,6 +860,7 @@ export async function createCheckoutSession(request: Request) {
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ["card"],
       mode: "payment",
+      allow_promotion_codes: true,
       line_items: [
         {
           price_data: {

--- a/app/routes/dashboard/payment.tsx
+++ b/app/routes/dashboard/payment.tsx
@@ -487,6 +487,7 @@ export async function action({ request }: { request: Request }) {
       const session = await stripe.checkout.sessions.create({
         payment_method_types: ["card"],
         mode: "payment",
+        allow_promotion_codes: true,
         line_items: [
           {
             price_data: {
@@ -555,6 +556,7 @@ export async function action({ request }: { request: Request }) {
       const session = await stripe.checkout.sessions.create({
         payment_method_types: ["card"],
         mode: "payment",
+        allow_promotion_codes: true,
         line_items: [
           {
             price_data: {


### PR DESCRIPTION
## Summary

This PR adds coupon code support to all Stripe checkout sessions and includes user-friendly notifications for the quick checkout feature. Resolves #195 

## Changes Made

### Stripe Checkout Configuration
- Added `allow_promotion_codes: true` to all Stripe checkout session creation calls
- Updated workshop checkout sessions in both `app/models/payment.server.ts` and `app/routes/dashboard/payment.tsx`
- Updated membership and equipment checkout sessions in `app/models/payment.server.ts`

### User Experience Improvements
- Added coupon code notice badge to QuickCheckout component header
- Implemented tooltip with clear instructions for users with coupon codes

## Technical Details

### Files Modified
- `app/models/payment.server.ts` - Added promotion code support to 4 checkout session types
- `app/routes/dashboard/payment.tsx` - Added promotion code support to 2 workshop checkout paths
- `app/components/ui/Dashboard/quickcheckout.tsx` - Added coupon notice badge and tooltip

### Checkout Session Updates
All Stripe checkout sessions now include:
```typescript
allow_promotion_codes: true
```

## User Impact

- Customers can now apply coupon codes during checkout for any payment type
- Quick checkout users are informed about coupon code availability
- Clear guidance directs users to use Stripe checkout when they have promotion codes

## Testing

- Verify promotion code field appears in Stripe checkout for all payment types
- Confirm coupon codes are properly validated and applied by Stripe
- Test tooltip functionality on quick checkout coupon badge