### PR TITLE
Remove Email Autofill from Stripe Checkout and Update Button Text

### DIFF
--- a/app/models/payment.server.ts
+++ b/app/models/payment.server.ts
@@ -629,7 +629,6 @@ export async function createCheckoutSession(request: Request) {
       userId,
       compensationPrice,
       oldMembershipNextPaymentDate,
-      userEmail,
     } = body; // <--- Note we read compensationPrice here
     if (!membershipPlanId || !price || !userId) {
       throw new Error("Missing required membership payment data");
@@ -677,7 +676,6 @@ export async function createCheckoutSession(request: Request) {
           quantity: 1,
         },
       ],
-      customer_email: userEmail,
       success_url: `http://localhost:5173/dashboard/payment/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `http://localhost:5173/dashboard/memberships`,
       metadata: {
@@ -699,8 +697,7 @@ export async function createCheckoutSession(request: Request) {
   }
   // Workshop Single Occurrence Payment
   else if (body.workshopId && body.occurrenceId) {
-    const { workshopId, occurrenceId, price, userId, userEmail, variationId } =
-      body;
+    const { workshopId, occurrenceId, price, userId, variationId } = body;
     if (!workshopId || !occurrenceId || !price || !userId) {
       throw new Error("Missing required payment data");
     }
@@ -745,7 +742,6 @@ export async function createCheckoutSession(request: Request) {
           quantity: 1,
         },
       ],
-      customer_email: userEmail,
       success_url: `http://localhost:5173/dashboard/payment/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `http://localhost:5173/dashboard/workshops`,
       metadata: {
@@ -764,8 +760,7 @@ export async function createCheckoutSession(request: Request) {
 
   // Multi-day Workshop Payment
   else if (body.workshopId && body.connectId) {
-    const { workshopId, connectId, price, userId, userEmail, variationId } =
-      body;
+    const { workshopId, connectId, price, userId, variationId } = body;
     if (!workshopId || !connectId || !price || !userId) {
       throw new Error("Missing required payment data");
     }
@@ -817,7 +812,6 @@ export async function createCheckoutSession(request: Request) {
           quantity: 1,
         },
       ],
-      customer_email: userEmail,
       success_url: `http://localhost:5173/dashboard/payment/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `http://localhost:5173/dashboard/workshops`,
       metadata: {
@@ -842,15 +836,7 @@ export async function createCheckoutSession(request: Request) {
     body.userId &&
     body.slotsDataKey
   ) {
-    const {
-      equipmentId,
-      slotCount,
-      price,
-      userId,
-      slots,
-      userEmail,
-      slotsDataKey,
-    } = body;
+    const { equipmentId, slotCount, price, userId, slots, slotsDataKey } = body;
 
     // Calculate GST
     const gstPercentage = await getAdminSetting("gst_percentage", "5");
@@ -874,7 +860,6 @@ export async function createCheckoutSession(request: Request) {
           quantity: 1,
         },
       ],
-      customer_email: userEmail,
       success_url: `http://localhost:5173/dashboard/payment/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `http://localhost:5173/dashboard/equipment`,
       metadata: {

--- a/app/routes/dashboard/equipmentbooking.tsx
+++ b/app/routes/dashboard/equipmentbooking.tsx
@@ -175,7 +175,6 @@ export async function action({ request }: { request: Request }) {
       body: JSON.stringify({
         equipmentId,
         userId: user.id,
-        userEmail: user.email,
         price: totalPrice,
         slotCount: slotCount,
         slotsDataKey: slotsDataKey.toString(),
@@ -496,9 +495,7 @@ export default function EquipmentBookingForm() {
                     selectedSlots.length === 0
                   }
                 >
-                  {navigation.state === "submitting"
-                    ? "Booking..."
-                    : "Proceed to Payment"}
+                  {navigation.state === "submitting" ? "Booking..." : "Proceed"}
                 </Button>
               </div>
             </Form>

--- a/app/routes/dashboard/payment.tsx
+++ b/app/routes/dashboard/payment.tsx
@@ -430,7 +430,6 @@ export async function action({ request }: { request: Request }) {
             quantity: 1,
           },
         ],
-        customer_email: user.email,
         success_url: `http://localhost:5173/dashboard/payment/success?session_id={CHECKOUT_SESSION_ID}`,
         cancel_url: `http://localhost:5173/dashboard/memberships`,
         metadata: {
@@ -503,7 +502,6 @@ export async function action({ request }: { request: Request }) {
             quantity: 1,
           },
         ],
-        customer_email: user.email,
         success_url: `http://localhost:5173/dashboard/payment/success?session_id={CHECKOUT_SESSION_ID}`,
         cancel_url: `http://localhost:5173/dashboard/workshops`,
         metadata: {
@@ -572,7 +570,6 @@ export async function action({ request }: { request: Request }) {
             quantity: 1,
           },
         ],
-        customer_email: user.email,
         success_url: `http://localhost:5173/dashboard/payment/success?session_id={CHECKOUT_SESSION_ID}`,
         cancel_url: `http://localhost:5173/dashboard/workshops`,
         metadata: {


### PR DESCRIPTION
**Closes #199**

## Summary
Removes email autofill from all Stripe Checkout sessions and updates equipment booking button label for consistency.

## Changes Made

### Backend Changes
- **`app/models/payment.server.ts`**: Removed `customer_email` parameter from all Stripe Checkout session creations (memberships, workshops, equipment)
- **`app/routes/dashboard/payment.tsx`**: Removed `customer_email` parameter from all Stripe Checkout session creations

### Frontend Changes  
- **`app/routes/dashboard/equipmentbooking.tsx`**: 
  - Changed button label from "Proceed to Payment" to "Proceed"
  - Removed unused `userEmail` parameter from checkout session request

## Impact
- Users can now enter any email address during Stripe Checkout instead of being locked to their account email
- Email addresses entered during checkout are not persisted to user accounts
- Equipment booking UI now matches quick checkout button labeling
- All checkout flows (memberships, workshops, equipment) behave consistently

## Testing
- Verify email field is editable in Stripe Checkout for all payment types
- Confirm equipment booking button displays "Proceed" instead of "Proceed to Payment"
- Test that checkout-entered emails are used only for Stripe receipts