### PR TITLE
Add Non-Monthly Subscription Upgrade/Downgrade Restriction Alert

### DIFF
--- a/app/routes/dashboard/membershipdetails.tsx
+++ b/app/routes/dashboard/membershipdetails.tsx
@@ -505,6 +505,15 @@ export default function MembershipDetails() {
                     Select Billing Cycle
                   </h2>
 
+                  {/* Warning for new subscribers selecting non-monthly billing cycles */}
+                  {!userActiveMembership && selectedBillingCycle !== "monthly" && (
+                    <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded">
+                      <p className="text-sm text-gray-700">
+                        <strong>Important:</strong> If you select a non-monthly billing cycle, you will not be able to upgrade or downgrade your subscription until the billing period ends. You will need to cancel and resubscribe to change plans.
+                      </p>
+                    </div>
+                  )}
+
                   {/* Warning for non-monthly billing cycles when upgrading/downgrading */}
                   {userActiveMembership && userActiveMembership.billingCycle !== "monthly" && (
                     <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded">


### PR DESCRIPTION
## Summary

This PR adds a warning banner to inform new subscribers about upgrade/downgrade restrictions when selecting non-monthly billing cycles. 

Resolves #228 

## Implementation Details

The warning banner:
- Only shows for new subscribers (no active membership)
- Triggers when non-monthly billing cycle is selected

## Testing

- Warning appears when new subscriber selects quarterly/semiannually/yearly billing
- Warning does not appear for monthly billing selection
- Warning does not appear for existing subscribers with active memberships