### PR TITLE
Fix Equipment Prerequisite Validation on Booking Page

### DIFF
--- a/app/routes/dashboard/equipmentbooking.tsx
+++ b/app/routes/dashboard/equipmentbooking.tsx
@@ -77,10 +77,14 @@ export async function loader({
       "../../models/equipment.server"
     );
 
-    for (const equip of equipmentWithSlots) {
-      equipmentPrerequisiteMap[equip.id] =
-        await hasUserCompletedEquipmentPrerequisites(user.id, equip.id);
-    }
+    const prerequisitePromises = equipmentWithSlots.map((equip) =>
+      hasUserCompletedEquipmentPrerequisites(user.id, equip.id)
+    );
+    const prerequisiteResults = await Promise.all(prerequisitePromises);
+
+    equipmentWithSlots.forEach((equip, index) => {
+      equipmentPrerequisiteMap[equip.id] = prerequisiteResults[index];
+    });
   }
 
   const visibleDays = await getAdminSetting(


### PR DESCRIPTION
## Problem

When users change the equipment dropdown on the booking page, the prerequisite check was not updating. This caused two critical issues:

- Users could book equipment they were not oriented on by switching from equipment they were oriented on

- Users were blocked from booking equipment they were oriented on after switching from equipment they were not oriented on

## Root Cause

The prerequisite check was only performed once during the initial page load for the equipment ID from the URL params. When users changed the dropdown selection, the component state updated but the prerequisite validation status did not refresh for the newly selected equipment.

## Solution

1. **Loader Enhancement**: Modified the loader to check prerequisites for all available equipment upfront and return an `equipmentPrerequisiteMap`

	- Prerequisite checks for all equipment are executed in parallel using `Promise.all()` to minimize load time overhead

	- This improves UX when switching between equipments by having all prerequisite statuses pre-computed

3. **Dynamic State Management**: Added state tracking for the current equipment's prerequisite status that updates when the dropdown changes

4. **UI Updates**: Updated the booking grid to use the dynamic prerequisite status instead of the static initial value

5. **Server-Side Validation**: Added prerequisite validation in the action function to prevent bypassing client-side checks

6. **Performance Optimization**: Refactored sequential prerequisite checks to run in parallel, significantly reducing load time when multiple equipment items need validation

Resolves #236 

## Changes

- `app/routes/dashboard/equipmentbooking.tsx`

  - Check prerequisites for all equipment in loader (optimized with parallel execution)

  - Return `equipmentPrerequisiteMap` with prerequisite status for each equipment

  - Add `currentEquipmentHasPrerequisites` state that updates with dropdown changes

  - Replace static prerequisite check with dynamic check in booking grid

  - Add server-side prerequisite validation in action handler

## Testing

- [ ] User without orientation cannot book equipment on initial load
- [ ] User without orientation cannot book equipment after changing dropdown
- [ ] User with orientation can book equipment on initial load
- [ ] User with orientation can book equipment after changing dropdown
- [ ] Switching from oriented to non-oriented equipment blocks booking
- [ ] Switching from non-oriented to oriented equipment allows booking
- [ ] Server-side validation prevents direct form submission bypass