### PR TITLE
Add result and date filters with sort to workshop users page

### DIFF
--- a/.claude/commands/read-docs.md
+++ b/.claude/commands/read-docs.md
@@ -1,0 +1,119 @@
+You are onboarding yourself to this codebase at the start of a conversation. Your goal is to build an accurate, verified mental model of the system — not to read docs and accept them at face value, but to read the actual source code and confirm what is real.
+
+Do not summarize as you go. Do not report progress mid-way. Read everything first, then produce one honest summary at the end.
+
+---
+
+## Phase 1 — Read all four documentation files in full
+
+Read every line of each file. Do not skim.
+
+- `CLAUDE.md`
+- `PROJECT.md`
+- `README.md`
+- `docs/msyk-overview.md`
+
+After reading, note any claims that need verification against the code (e.g. "cron runs every 15s", "emails stored as lowercase", "seed only runs in development"). You will verify these in Phase 2.
+
+---
+
+## Phase 2 — Read the source code in full
+
+Read every file listed below completely. If a file is too long to read in one call, read it in chunks — do not stop until you have read all of it.
+
+**Schema (read first — everything else references it):**
+- `prisma/schema.prisma`
+
+**Models (all of them):**
+- `app/models/user.server.ts`
+- `app/models/workshop.server.ts`
+- `app/models/equipment.server.ts`
+- `app/models/membership.server.ts`
+- `app/models/payment.server.ts`
+- `app/models/profile.server.ts`
+- `app/models/admin.server.ts`
+- `app/models/access_card.server.ts`
+- `app/models/accessLog.server.ts`
+- `app/models/issue.server.ts`
+
+**Services:**
+- `app/services/brivo.server.ts`
+- `app/services/access-control-sync.server.ts`
+- `app/services/stripe-sync.server.ts`
+
+**Utilities:**
+- `app/utils/session.server.ts`
+- `app/utils/db.server.ts`
+- `app/utils/email.server.ts`
+- `app/utils/googleCalendar.server.ts`
+
+**Config and logging:**
+- `app/config/access-control.ts`
+- `app/logging/logger.ts`
+
+**Server entry (cron jobs start here):**
+- `entry.server.ts`
+
+**Seed script:**
+- `seed.ts`
+
+**Root config:**
+- `package.json`
+- `app/routes.ts`
+
+**Routes — read all files in these directories:**
+
+Run this to get the full list:
+```bash
+find app/routes -name "*.ts" -o -name "*.tsx" | sort
+```
+
+Then read every file in the list. Do not skip any route file.
+
+---
+
+## Phase 3 — Verify the documentation against what you read
+
+Go through every factual claim in the four doc files and check it against what you actually saw in the source files. Be honest. Do not rationalize discrepancies away.
+
+Check at minimum:
+
+- Every command listed in CLAUDE.md and PROJECT.md — does it match `package.json` scripts?
+- Every cron job schedule — does it match the actual `node-cron` or `setInterval` call?
+- Every env var mentioned — does it actually appear in the source files?
+- Every model and field name — does it match `schema.prisma`?
+- Every route in the route map — does it exist in `app/routes.ts` and the route files?
+- Every model function listed — does it actually exist in the model file?
+- Session behavior (3-hour timeout, `loginTime` validation) — verified in `session.server.ts`?
+- Email case normalization — verified in `session.server.ts`?
+- Seed guard (NODE_ENV check) — verified in `seed.ts`?
+- Role level logic — verified in `user.server.ts`?
+- Stripe sync hooks — are they actually called from model create/update/delete functions?
+- Brivo integration — does it gracefully degrade when env vars are missing?
+
+---
+
+## Phase 4 — Report
+
+After completing all three phases, produce a single report with these sections:
+
+### Verified Understanding
+A concise but complete summary of how the system actually works, based on what you read. Cover:
+- Tech stack and architecture
+- Auth and session behavior
+- Role level system and how it's calculated and synced
+- Cron jobs (exact schedules confirmed from code)
+- Workshop system (offer pattern, occurrence status, multi-day, prerequisites)
+- Equipment booking system
+- Membership system (billing, auto-renew, revocation)
+- Payment flow (Stripe Checkout vs Quick Checkout, GST)
+- Stripe Product Sync
+- Brivo and ESP32 door access (two separate systems)
+- Email system
+- Seed script behavior
+
+### Discrepancies Found
+List every place where the documentation says something that does not match the code. Be specific: quote the doc claim and describe what the code actually does. If you found none, say so explicitly.
+
+### Ready
+One line confirming you have read all files and are ready to help with tasks in this codebase.

--- a/.claude/commands/update-docs.md
+++ b/.claude/commands/update-docs.md
@@ -1,0 +1,101 @@
+You are updating the project documentation after a feature branch has been implemented. Your job is to make the docs truthful — not aspirational, not stale. Every claim you write must be traceable to code you personally read during this session.
+
+## Rules
+
+1. **Read before you write.** Do not update any documentation file until you have read the source files that justify the update.
+2. **Branch-scoped.** You are documenting what changed in *this branch* vs main. Focus on the diff. Do not rewrite sections unrelated to the changes.
+3. **Cite your evidence.** For every update you make, you must have read the relevant file. If you're unsure, re-read it.
+4. **Remove stale content.** If existing docs describe something the new code contradicts or replaces, correct or remove it.
+5. **Do not invent.** Do not document features, flags, patterns, or behaviors you did not observe in actual files.
+
+---
+
+## Phase 1 — Understand what changed in this branch
+
+Run these commands to get the full picture of what this branch adds or modifies:
+
+```bash
+# What branch are we on and what commits are new
+git log main..HEAD --oneline
+
+# What files were changed vs main
+git diff main..HEAD --name-only
+
+# Full diff for context (to understand intent, not to substitute for reading files)
+git diff main..HEAD --stat
+```
+
+Study the output carefully before proceeding. Build a mental model of what this branch does.
+
+---
+
+## Phase 2 — Read every changed source file in full
+
+From the file list in Phase 1, read every changed or added source file (`.ts`, `.tsx`, `.prisma`) in full. Do not skip files. If a file is long, read it in chunks.
+
+Pay special attention to:
+- New or modified Prisma models in `prisma/schema.prisma`
+- New or modified model functions in `app/models/`
+- New or modified services in `app/services/`
+- New or modified utilities in `app/utils/`
+- New or modified routes in `app/routes/`
+- New environment variables referenced in any file
+- New cron jobs, background tasks, or startup hooks
+- New or changed auth/session behavior
+- New or changed role/permission logic
+
+For each file you read, note:
+- What it does now
+- What it used to do (based on the diff)
+- What doc sections are affected
+
+---
+
+## Phase 3 — Read the existing documentation
+
+Read all four documentation files in full before making any changes:
+
+- `CLAUDE.md`
+- `PROJECT.md`
+- `README.md`
+- `docs/msyk-overview.md`
+
+Note which sections are outdated, missing the new feature, or contradicted by what you read in Phase 2.
+
+---
+
+## Phase 4 — Update the docs
+
+Update only the sections affected by this branch's changes. Do not rewrite unrelated sections.
+
+| File | What to focus on |
+|------|-----------------|
+| `CLAUDE.md` | Quick-reference commands, critical notes, project structure if it changed |
+| `PROJECT.md` | Architecture, models, services, integrations, route map, env vars |
+| `README.md` | Setup instructions, user documentation, system architecture, database schema |
+| `docs/msyk-overview.md` | Functional workflows, feature descriptions, business logic |
+
+For each affected section:
+- Add documentation for real features/patterns/flows introduced in this branch
+- Correct any commands, file paths, model names, or descriptions made wrong by this branch
+- Remove or update any content that the new code replaces or contradicts
+
+If this branch adds a new database migration, document the new models and fields.
+If this branch adds a new env var, add it to the env var tables in PROJECT.md and README.md.
+If this branch adds a new route, add it to the route map in PROJECT.md.
+If this branch adds a new cron job or background task, add it to the cron jobs table in PROJECT.md and CLAUDE.md.
+
+---
+
+## Phase 5 — Verify
+
+After updating, re-read each doc you changed. For every claim, ask: "Can I point to a specific file that justifies this?" If not, fix it.
+
+Then run:
+
+```bash
+# Confirm the docs you changed
+git diff --name-only
+```
+
+List the files you updated and one-line summary of what changed in each.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ npm run dev                           # Start dev server (localhost:5173)
 npm run typecheck                     # Type check + generate React Router types
 npx prisma generate --schema prisma/schema.prisma  # Generate Prisma client
 npx prisma migrate dev                # Run migrations
-npx tsx seed.ts                       # Seed database
+npx tsx seed.ts                       # Seed database (NODE_ENV=development only)
 npx prisma studio                     # Open database GUI
 npm test                              # Run Jest tests
 ```

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -368,7 +368,9 @@ logger.error("Operation failed", { error, userId, context });
 - Jest configured for unit testing
 - Test files in `tests/` directory
 - Key test files: `tests/models/membership.server.test.ts`, `tests/models/membership.cron.test.ts`, `tests/models/workshop.registration.test.ts`, `tests/models/workshop.capacity.test.ts`
-- Seed script (`seed.ts`) provides consistent test data
+- Seed script (`seed.ts`) provides consistent test data; **requires `NODE_ENV=development`** — exits immediately otherwise. Occurrence dates are relative to `now` (e.g. `addDays(now, 7)`) so workshops always appear upcoming regardless of when the seed runs.
+- Additional test data scripts in `test-scripts/`:
+  - `seed-orientation-registrations.ts` — populates any workshop with 20 test users across 5 past sessions with varied results (passed/failed/pending/cancelled) and optional price variations; supports multi-day via `--days=N`. Run: `npx tsx test-scripts/seed-orientation-registrations.ts [workshopId|name] [--days=N]`
 
 ## Environment Variables & Configuration
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A comprehensive membership management platform built with React Router 7, TypeSc
 ### Additional Development Commands
 
 - **Type checking:** `npm run typecheck`
-- **Database seeding:** `npx tsx seed.ts`
+- **Database seeding:** `npx tsx seed.ts` *(requires `NODE_ENV=development`)*
 - **Prisma Studio:** `npx prisma studio`
 - **Run tests:** `npm test`
 
@@ -191,7 +191,11 @@ After login, users are redirected to role-appropriate dashboards:
 - Edit existing workshops in `/dashboard/editworkshop/:workshopId`
 - Offer workshops again with new occurrence scheduling in `/dashboard/workshops/offer/:id`
 - Manage workshop pricing variations in `/dashboard/workshops/pricevariations/:workshopId`
-- View all workshop registrations in `/dashboard/admin/workshop/users`
+- View registrations per workshop at `/dashboard/admin/workshop/:workshopId/users` with:
+  - **Result filter** — show only passed / failed / pending / cancelled registrations
+  - **Date filter** — show only users who attended on a specific occurrence date (useful for bulk-passing an orientation session)
+  - **Sort** — by last name, first name, registration date, or occurrence date(s); ascending or descending
+  - Multi-day workshops show a collapsible row with per-day results; all filters work across both single-day and multi-day workshops
 - Cancel workshop occurrences and price variations
 
 **Equipment Administration:**

--- a/app/routes/dashboard/userworkshop.tsx
+++ b/app/routes/dashboard/userworkshop.tsx
@@ -114,6 +114,12 @@ export default function WorkshopUsers() {
 
   const [searchUser, setSearchUser] = useState("");
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [resultFilter, setResultFilter] = useState("all");
+  const [dateFilter, setDateFilter] = useState("");
+  const [sortBy, setSortBy] = useState<
+    "lastName" | "firstName" | "occurrenceDate" | "registrationDate"
+  >("lastName");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
 
   // Determine the workshop name and type
   const workshopName =
@@ -164,19 +170,67 @@ export default function WorkshopUsers() {
     return Array.from(groups.values());
   }, [registrations]);
 
-  // Filter by user name
+  // Determine a group's effective result for filtering purposes
+  const getGroupEffectiveResult = (group: GroupedRegistration): string => {
+    const results = group.registrations.map((r) => r.result);
+    if (results.every((r) => r === "cancelled")) return "cancelled";
+    const nonCancelled = results.filter((r) => r !== "cancelled");
+    if (nonCancelled.length === 0) return "cancelled";
+    if (nonCancelled.some((r) => r === "failed")) return "failed";
+    if (nonCancelled.every((r) => r === "passed")) return "passed";
+    return "pending";
+  };
+
+  // Filter by user name, result, and occurrence date
   const filteredGroups = useMemo(() => {
     return groupedRegistrations.filter((group) => {
       const userName =
         `${group.userFirstName} ${group.userLastName}`.toLowerCase();
-      return searchUser === "" || userName.includes(searchUser.toLowerCase());
-    });
-  }, [groupedRegistrations, searchUser]);
+      if (searchUser !== "" && !userName.includes(searchUser.toLowerCase()))
+        return false;
 
-  // Sort by user ID
+      if (resultFilter !== "all") {
+        if (getGroupEffectiveResult(group) !== resultFilter) return false;
+      }
+
+      if (dateFilter) {
+        const hasMatchingDate = group.registrations.some((reg) => {
+          const d = new Date(reg.occurrence.startDate);
+          const occDateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+          return occDateStr === dateFilter;
+        });
+        if (!hasMatchingDate) return false;
+      }
+
+      return true;
+    });
+  }, [groupedRegistrations, searchUser, resultFilter, dateFilter]);
+
+  // Sort by selected field and direction
   const sortedGroups = useMemo(() => {
-    return filteredGroups.slice().sort((a, b) => a.userId - b.userId);
-  }, [filteredGroups]);
+    return filteredGroups.slice().sort((a, b) => {
+      let cmp = 0;
+      if (sortBy === "occurrenceDate") {
+        cmp =
+          new Date(a.registrations[0].occurrence.startDate).getTime() -
+          new Date(b.registrations[0].occurrence.startDate).getTime();
+      } else if (sortBy === "registrationDate") {
+        cmp =
+          new Date(a.registrations[0].date as string).getTime() -
+          new Date(b.registrations[0].date as string).getTime();
+      } else if (sortBy === "firstName") {
+        cmp =
+          a.userFirstName.localeCompare(b.userFirstName) ||
+          a.userLastName.localeCompare(b.userLastName);
+      } else {
+        // lastName (default)
+        cmp =
+          a.userLastName.localeCompare(b.userLastName) ||
+          a.userFirstName.localeCompare(b.userFirstName);
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+  }, [filteredGroups, sortBy, sortDir]);
 
   const toggleGroup = (key: string) => {
     setExpandedGroups((prev) => {
@@ -283,6 +337,105 @@ export default function WorkshopUsers() {
             </TooltipProvider>
           </div>
 
+          {/* Filter / Sort Controls */}
+          <div className="flex flex-wrap items-center gap-3 mb-6">
+            {/* Result filter */}
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600 whitespace-nowrap">
+                Result:
+              </span>
+              <Select value={resultFilter} onValueChange={setResultFilter}>
+                <SelectTrigger className="w-36">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Results</SelectItem>
+                  <SelectItem value="passed">Passed</SelectItem>
+                  <SelectItem value="failed">Failed</SelectItem>
+                  <SelectItem value="pending">Pending</SelectItem>
+                  <SelectItem value="cancelled">Cancelled</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Date filter (occurrence date) */}
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600 whitespace-nowrap">
+                Date:
+              </span>
+              <Input
+                type="date"
+                value={dateFilter}
+                onChange={(e) => setDateFilter(e.target.value)}
+                className="w-40"
+              />
+              {dateFilter && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setDateFilter("")}
+                  className="h-8 px-2 text-gray-500"
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+
+            {/* Sort */}
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600 whitespace-nowrap">
+                Sort:
+              </span>
+              <Select
+                value={sortBy}
+                onValueChange={(v) =>
+                  setSortBy(
+                    v as "lastName" | "firstName" | "occurrenceDate" | "registrationDate"
+                  )
+                }
+              >
+                <SelectTrigger className="w-44">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="lastName">Last Name (A–Z)</SelectItem>
+                  <SelectItem value="firstName">First Name (A–Z)</SelectItem>
+                  <SelectItem value="registrationDate">
+                    Registration Date
+                  </SelectItem>
+                  <SelectItem value="occurrenceDate">
+                    Occurrence Date(s)
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() =>
+                  setSortDir((d) => (d === "asc" ? "desc" : "asc"))
+                }
+                className="h-8 px-2 text-gray-500"
+              >
+                {sortDir === "asc" ? "↑ Asc" : "↓ Desc"}
+              </Button>
+            </div>
+
+            {/* Clear all filters */}
+            {(resultFilter !== "all" || dateFilter) && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setResultFilter("all");
+                  setDateFilter("");
+                }}
+                className="h-8 text-gray-500"
+              >
+                Clear filters
+              </Button>
+            )}
+          </div>
+
           {/* Grouped Registrations Table */}
           <div className="border rounded-lg overflow-hidden">
             <table className="w-full">
@@ -307,7 +460,7 @@ export default function WorkshopUsers() {
                     Registration Date
                   </th>
                   <th className="px-4 py-3 text-left text-sm font-medium text-gray-700">
-                    Dates
+                    Occurrence Date(s)
                   </th>
                 </tr>
               </thead>
@@ -318,7 +471,9 @@ export default function WorkshopUsers() {
                       colSpan={7}
                       className="px-4 py-8 text-center text-gray-500"
                     >
-                      No users registered for this workshop
+                      {groupedRegistrations.length === 0
+                        ? "No users registered for this workshop"
+                        : "No users match the current filters"}
                     </td>
                   </tr>
                 ) : (

--- a/docs/implementations/opus-doc-audit-prompt.md
+++ b/docs/implementations/opus-doc-audit-prompt.md
@@ -1,0 +1,88 @@
+# Opus 4.7 — Full Codebase Documentation Audit Prompt
+
+Paste this entire prompt into a Claude Opus 4.7 session to run a documentation audit.
+
+---
+
+Use extended thinking for this entire task. Think deeply and carefully at every step before acting. Do not shortcut or skim.
+
+You are auditing and updating the documentation for this codebase. Your job is to make the docs truthful — not aspirational, not stale. Every claim you write must be traceable to code you personally read during this session.
+
+## Rules
+
+1. **Read before you write.** Do not update any documentation file until you have read the source files that justify the update.
+2. **Cite your evidence.** For each change you make, you must have seen the relevant logic in an actual file. If you're unsure, re-read the file.
+3. **Remove stale content.** If docs describe something you cannot find in the code, remove or correct it.
+4. **Do not invent.** Do not document features, flags, patterns, or behaviors you did not personally observe in the code.
+
+## Process
+
+**Phase 1 — Map the codebase**
+
+Run the following to get the full file list. Study the structure before reading anything.
+
+```bash
+find . -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.prisma" -o -name "*.json" \) \
+  | grep -v node_modules | grep -v .git | grep -v dist | sort
+```
+
+**Phase 2 — Read systematically**
+
+Read every file in these directories in full, in order:
+
+- `prisma/schema.prisma` — full schema
+- `app/models/` — all server models
+- `app/services/` — all service files
+- `app/utils/` — all utilities
+- `app/routes/` — all route files (loaders, actions, components)
+- `app/config/` — all config files
+- `app/logging/` — logger setup
+- `app/layouts/` — layout components
+- `app/components/` — UI components
+- Root config files: `package.json`, `vite.config.ts`, `react-router.config.ts`, `tsconfig.json`
+
+Do not skip files. If a file is long, read it in chunks until you have read all of it.
+
+**Phase 3 — Read existing docs**
+
+Read these four documentation files in full before making any changes:
+
+- `CLAUDE.md`
+- `PROJECT.md`
+- `README.md`
+- `docs/msyk-overview.md`
+
+**Phase 4 — Update docs**
+
+Update only these four files to match reality:
+
+| File | What to focus on |
+|------|-----------------|
+| `CLAUDE.md` | Quick-reference commands, project structure, critical notes |
+| `PROJECT.md` | Architecture, models, services, integrations, route map, env vars |
+| `README.md` | Setup instructions, user documentation, system architecture, database schema |
+| `docs/msyk-overview.md` | Functional workflows, feature descriptions, business logic |
+
+For each file:
+
+- Correct any commands, file paths, model names, or architectural descriptions that are wrong
+- Add documentation for real features/patterns/flows you found but are not documented
+- Remove documentation for things you could not find in the code
+
+**Phase 5 — Verify**
+
+After updating, re-read each doc you changed and ask: "Can I point to a specific file and line that justifies every claim in here?" If not, fix it.
+
+## What to document
+
+- Actual commands that work (verify against `package.json` scripts)
+- Actual environment variables referenced in code
+- Actual database models and their fields (from `schema.prisma`)
+- Actual integrations and which files implement them
+- Actual auth/session behavior
+- Actual cron jobs and their intervals
+- Actual role/permission logic
+- Actual API routes and what they do
+- Any TODOs, known limitations, or in-progress work found in the code
+
+Begin now. Think carefully at each phase before proceeding.

--- a/docs/msyk-overview.md
+++ b/docs/msyk-overview.md
@@ -162,10 +162,19 @@ The MSYK Membership Management System is a comprehensive platform for managing m
 - Stripe refund processed
 - Cancellation confirmation email sent
 
+**Admin — Workshop Registrations Page (`/dashboard/admin/workshop/:workshopId/users`):**
+- Lists all users registered for a specific workshop or orientation
+- **Result filter**: show only passed / failed / pending / cancelled registrations
+- **Date filter**: filter by occurrence date — e.g. select a date to see everyone who attended an orientation session that day, then use "Pass All" to pass the whole cohort
+- **Sort**: last name (A–Z), first name (A–Z), registration date, or occurrence date(s); direction toggleable
+- Multi-day workshops group all days per user into one expandable row; per-day results shown on expand; all filters operate on the group's effective result (e.g. a user is "passed" only when all days pass)
+- Works identically for orientation and regular workshop types, single-day and multi-day, with or without price variations
+
 **Key Files:**
 - `app/models/workshop.server.ts` - Workshop CRUD, occurrence management, registration
 - `app/models/payment.server.ts` - Workshop payment and refund processing
 - `app/routes/dashboard/workshops.tsx` - Workshop browsing and registration
+- `app/routes/dashboard/userworkshop.tsx` - Per-workshop registrations list with result/date filters and sort
 
 ### 6. Equipment Booking System
 

--- a/seed.ts
+++ b/seed.ts
@@ -2,8 +2,14 @@ import { PrismaClient } from "@prisma/client";
 import bcrypt from "bcryptjs";
 const prisma = new PrismaClient();
 
-// Run npx tsx seed.ts
+// Run npx tsx seed.ts (only in development)
 async function main() {
+  const env = process.env.NODE_ENV;
+  if (env !== "development") {
+    console.error(`Seed aborted: NODE_ENV is "${env}". Only runs in development.`);
+    process.exit(1);
+  }
+
   await prisma.adminSettings.deleteMany();
   await prisma.userMembership.deleteMany();
   await prisma.user.deleteMany();
@@ -124,64 +130,159 @@ async function main() {
     data: [
       {
         name: "Laser Cutting Basics",
-        description: "Learn how to use a laser cutter safely.",
+        description:
+          "Learn how to use the laser cutter safely and effectively. We'll cover material selection, design file preparation, and machine operation.",
         price: 30.0,
-        location: "Makerspace YK",
-        capacity: 15,
+        location: "Makerspace YK — Digital Lab",
+        capacity: 8,
         type: "workshop",
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 60,
       },
       {
-        name: "Pottery Workshop",
-        description: "Hands-on pottery techniques for beginners.",
-        price: 35.0,
+        name: "3D Printing Fundamentals",
+        description:
+          "Get hands-on with FDM 3D printing. Learn slicer software, print settings, and how to troubleshoot common issues.",
+        price: 25.0,
+        location: "Makerspace YK — Digital Lab",
+        capacity: 10,
+        type: "workshop",
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 60,
+      },
+      {
+        name: "Introduction to Woodworking",
+        description:
+          "A beginner-friendly workshop covering basic hand tools, power tool safety, and a guided small project build.",
+        price: 40.0,
+        location: "Makerspace YK — Shopspace",
+        capacity: 6,
+        type: "workshop",
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 60,
+      },
+      {
+        name: "General Orientation",
+        description:
+          "Required orientation for all new members. Covers safety rules, facility tour, tool overview, and membership access levels.",
+        price: 0.0,
         location: "Makerspace YK",
         capacity: 20,
-        type: "workshop",
+        type: "orientation",
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 30,
       },
       {
-        name: "Knitting for Beginners",
-        description: "Learn the basics of knitting.",
-        price: 22.0,
-        location: "Makerspace YK",
-        capacity: 25,
+        name: "Shopspace Orientation",
+        description:
+          "Required orientation for members who want to access the woodshop. Covers table saw, band saw, and other shop equipment.",
+        price: 0.0,
+        location: "Makerspace YK — Shopspace",
+        capacity: 8,
         type: "orientation",
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 30,
+      },
+      {
+        name: "Soldering & Electronics Basics",
+        description:
+          "Learn to solder, read basic circuits, and assemble a small take-home electronics project.",
+        price: 20.0,
+        location: "Makerspace YK — Hackspace",
+        capacity: 12,
+        type: "workshop",
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 60,
       },
     ],
   });
 
+  const addDays = (date: Date, days: number) => {
+    const d = new Date(date);
+    d.setDate(d.getDate() + days);
+    return d;
+  };
+
   const baseOccurrencesData = [
+    // Laser Cutting — two upcoming sessions
     {
-      workshopId: 1, // Laser Cutting
-      startDate: new Date("2025-02-10T10:00:00Z"),
-      endDate: new Date("2025-02-10T12:00:00Z"),
+      workshopId: 1,
+      startDate: addDays(now, 7),
+      endDate: addDays(now, 7),
     },
     {
-      workshopId: 1, // Laser Cutting again
-      startDate: new Date("2025-03-17T10:00:00Z"),
-      endDate: new Date("2025-03-17T12:00:00Z"),
+      workshopId: 1,
+      startDate: addDays(now, 21),
+      endDate: addDays(now, 21),
+    },
+    // 3D Printing — upcoming session
+    {
+      workshopId: 2,
+      startDate: addDays(now, 10),
+      endDate: addDays(now, 10),
+    },
+    // Woodworking — upcoming session
+    {
+      workshopId: 3,
+      startDate: addDays(now, 14),
+      endDate: addDays(now, 14),
+    },
+    // General Orientation — two upcoming sessions
+    {
+      workshopId: 4,
+      startDate: addDays(now, 5),
+      endDate: addDays(now, 5),
     },
     {
-      workshopId: 2, // Pottery
-      startDate: new Date("2025-09-10T14:00:00Z"),
-      endDate: new Date("2025-09-10T16:00:00Z"),
+      workshopId: 4,
+      startDate: addDays(now, 19),
+      endDate: addDays(now, 19),
+    },
+    // Shopspace Orientation — upcoming session
+    {
+      workshopId: 5,
+      startDate: addDays(now, 12),
+      endDate: addDays(now, 12),
+    },
+    // Soldering — upcoming session
+    {
+      workshopId: 6,
+      startDate: addDays(now, 28),
+      endDate: addDays(now, 28),
+    },
+    // Past occurrences (for "past events" section)
+    {
+      workshopId: 1,
+      startDate: addDays(now, -30),
+      endDate: addDays(now, -30),
     },
     {
-      workshopId: 3, // Knitting
-      startDate: new Date("2025-09-10T10:00:00Z"),
-      endDate: new Date("2025-09-10T12:00:00Z"),
+      workshopId: 2,
+      startDate: addDays(now, -14),
+      endDate: addDays(now, -14),
     },
   ];
 
-  // Map over each occurrence to set status based on startDate
+  // Set start/end times: each occurrence is 2 hours; past ones explicitly past status
   const workshopOccurrencesData = baseOccurrencesData.map((occ) => {
-    const isFuture = occ.startDate > now;
+    const start = new Date(occ.startDate);
+    start.setHours(10, 0, 0, 0);
+    const end = new Date(occ.endDate);
+    end.setHours(12, 0, 0, 0);
     return {
-      ...occ,
-      status: isFuture ? "active" : "past",
+      workshopId: occ.workshopId,
+      startDate: start,
+      endDate: end,
+      status: start > now ? "active" : "past",
     };
   });
 
-  // Now insert them into the database
   await prisma.workshopOccurrence.createMany({
     data: workshopOccurrencesData,
   });

--- a/test-scripts/seed-orientation-registrations.ts
+++ b/test-scripts/seed-orientation-registrations.ts
@@ -1,5 +1,5 @@
 /**
- * scripts/seed-orientation-registrations.ts
+ * test-scripts/seed-orientation-registrations.ts
  *
  * Seeds realistic test registrations for ANY workshop — orientation or regular,
  * single-day or multi-day, with or without price variations.
@@ -22,10 +22,10 @@
  *
  * Usage
  * ─────
- *   npx tsx scripts/seed-orientation-registrations.ts               # first orientation
- *   npx tsx scripts/seed-orientation-registrations.ts 5             # by workshop ID
- *   npx tsx scripts/seed-orientation-registrations.ts "Shopspace"   # by name (partial)
- *   npx tsx scripts/seed-orientation-registrations.ts 5 --days=3    # 3-day sessions
+ *   npx tsx test-scripts/seed-orientation-registrations.ts               # first orientation
+ *   npx tsx test-scripts/seed-orientation-registrations.ts 5             # by workshop ID
+ *   npx tsx test-scripts/seed-orientation-registrations.ts "Shopspace"   # by name (partial)
+ *   npx tsx test-scripts/seed-orientation-registrations.ts 5 --days=3    # 3-day sessions
  */
 
 import { PrismaClient } from "@prisma/client";

--- a/test-scripts/seed-orientation-registrations.ts
+++ b/test-scripts/seed-orientation-registrations.ts
@@ -1,0 +1,332 @@
+/**
+ * scripts/seed-orientation-registrations.ts
+ *
+ * Seeds realistic test registrations for ANY workshop — orientation or regular,
+ * single-day or multi-day, with or without price variations.
+ *
+ * What it auto-detects from the workshop record
+ * ─────────────────────────────────────────────
+ *   type                 → "orientation" shows passed/failed/pending dropdowns;
+ *                          "workshop" shows plain text result
+ *   hasPriceVariations   → true: uses/creates price variations and assigns some
+ *                          false: all registrations have priceVariationId = null
+ *
+ * What --days controls
+ * ────────────────────
+ *   1 (default)  → single-day sessions; each occurrence has no connectId
+ *   2+           → multi-day sessions; each session = N consecutive occurrences
+ *                  all sharing the same connectId (mirrors how the app works)
+ *                  Each user is registered for EVERY occurrence in their session
+ *
+ * Does NOT wipe existing data — safe to run alongside the main seed.
+ *
+ * Usage
+ * ─────
+ *   npx tsx scripts/seed-orientation-registrations.ts               # first orientation
+ *   npx tsx scripts/seed-orientation-registrations.ts 5             # by workshop ID
+ *   npx tsx scripts/seed-orientation-registrations.ts "Shopspace"   # by name (partial)
+ *   npx tsx scripts/seed-orientation-registrations.ts 5 --days=3    # 3-day sessions
+ */
+
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
+
+const prisma = new PrismaClient();
+
+// ── Parse CLI args ─────────────────────────────────────────────────────────────
+// argv[2] = workshop ID or name  (optional)
+// argv[*] = --days=N             (optional, default 1)
+const rawArgs = process.argv.slice(2);
+const workshopArg = rawArgs.find((a) => !a.startsWith("--")) ?? null;
+const daysArg = rawArgs.find((a) => a.startsWith("--days="));
+const DAYS_PER_SESSION = daysArg ? Math.max(1, parseInt(daysArg.split("=")[1], 10)) : 1;
+// ──────────────────────────────────────────────────────────────────────────────
+
+// 5 past sessions — first day of each session, relative to today
+const SESSION_OFFSETS: Array<{ daysAgo: number; startH: number }> = [
+  { daysAgo: 90, startH: 9  },
+  { daysAgo: 60, startH: 14 },
+  { daysAgo: 30, startH: 9  },
+  { daysAgo: 14, startH: 10 },
+  { daysAgo: 3,  startH: 9  },
+];
+
+// Duration of each day/occurrence in hours
+const SESSION_DURATION_H = 2;
+
+// 20 test users spread across 5 sessions (4 per session)
+// result intentionally varied so every filter value has matches
+type Result = "passed" | "failed" | "pending" | "cancelled";
+interface UserSpec {
+  firstName: string;
+  lastName: string;
+  result: Result;
+  regDaysBefore: number;    // registration date offset from session start
+  usePriceVar?: 0 | 1;     // index into priceVariations array; omit = no variation
+}
+
+const USER_SPECS: UserSpec[] = [
+  // Session 1
+  { firstName: "Alice",   lastName: "Johnson",  result: "passed",    regDaysBefore: 12 },
+  { firstName: "Bob",     lastName: "Smith",    result: "passed",    regDaysBefore: 8,  usePriceVar: 0 },
+  { firstName: "Carol",   lastName: "Williams", result: "failed",    regDaysBefore: 5 },
+  { firstName: "David",   lastName: "Brown",    result: "pending",   regDaysBefore: 3,  usePriceVar: 1 },
+  // Session 2
+  { firstName: "Emily",   lastName: "Jones",    result: "passed",    regDaysBefore: 14 },
+  { firstName: "Frank",   lastName: "Miller",   result: "passed",    regDaysBefore: 9,  usePriceVar: 0 },
+  { firstName: "Grace",   lastName: "Davis",    result: "failed",    regDaysBefore: 6 },
+  { firstName: "Henry",   lastName: "Wilson",   result: "pending",   regDaysBefore: 2 },
+  // Session 3
+  { firstName: "Isabel",  lastName: "Moore",    result: "passed",    regDaysBefore: 10 },
+  { firstName: "James",   lastName: "Taylor",   result: "passed",    regDaysBefore: 7,  usePriceVar: 1 },
+  { firstName: "Karen",   lastName: "Anderson", result: "failed",    regDaysBefore: 4 },
+  { firstName: "Leo",     lastName: "Thomas",   result: "pending",   regDaysBefore: 2 },
+  // Session 4
+  { firstName: "Maria",   lastName: "Jackson",  result: "passed",    regDaysBefore: 11 },
+  { firstName: "Nathan",  lastName: "White",    result: "passed",    regDaysBefore: 6,  usePriceVar: 0 },
+  { firstName: "Olivia",  lastName: "Harris",   result: "failed",    regDaysBefore: 4 },
+  { firstName: "Patrick", lastName: "Martin",   result: "pending",   regDaysBefore: 1 },
+  // Session 5 — includes "cancelled" to cover that filter value
+  { firstName: "Quinn",   lastName: "Thompson", result: "passed",    regDaysBefore: 9 },
+  { firstName: "Rachel",  lastName: "Garcia",   result: "cancelled", regDaysBefore: 5 },
+  { firstName: "Sam",     lastName: "Martinez", result: "pending",   regDaysBefore: 3,  usePriceVar: 1 },
+  { firstName: "Tina",    lastName: "Robinson", result: "pending",   regDaysBefore: 1 },
+];
+
+const USERS_PER_SESSION = 4; // must divide USER_SPECS.length evenly
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (process.env.NODE_ENV !== "development") {
+    console.error(`Aborted: NODE_ENV="${process.env.NODE_ENV}". Only runs in development.`);
+    process.exit(1);
+  }
+
+  // ── Find the workshop ────────────────────────────────────────────────────────
+  const workshopId =
+    workshopArg && /^\d+$/.test(workshopArg) ? Number(workshopArg) : null;
+  const workshopName = workshopArg && !workshopId ? workshopArg : null;
+
+  const workshop = workshopId
+    ? await prisma.workshop.findUnique({
+        where: { id: workshopId },
+        include: { priceVariations: true },
+      })
+    : await prisma.workshop.findFirst({
+        where: workshopName
+          ? { name: { contains: workshopName, mode: "insensitive" } }
+          : { type: "orientation" },
+        orderBy: { id: "asc" },
+        include: { priceVariations: true },
+      });
+
+  if (!workshop) {
+    const hint = workshopId
+      ? `ID ${workshopId}`
+      : workshopName
+      ? `"${workshopName}"`
+      : "any orientation";
+    console.error(`No workshop found (${hint}). Run the main seed first.`);
+    process.exit(1);
+  }
+
+  const isOrientation = workshop.type === "orientation";
+  console.log(
+    `\nWorkshop : "${workshop.name}" (ID ${workshop.id}, type: ${workshop.type})`
+  );
+  console.log(`Mode     : ${DAYS_PER_SESSION > 1 ? `multi-day (${DAYS_PER_SESSION} days/session)` : "single-day"}`);
+  console.log(
+    `Variations: ${workshop.hasPriceVariations ? "yes" : "no"}`
+  );
+
+  // ── Price variations — only when the workshop has them ──────────────────────
+  let priceVariations: { id: number; name: string }[] = [];
+
+  if (workshop.hasPriceVariations) {
+    priceVariations = workshop.priceVariations.filter((v) => v.status === "active");
+
+    if (priceVariations.length < 2) {
+      console.log("\n  Creating test price variations...");
+      const toCreate = [
+        { name: "Member",  price: 0,  description: "Current members",    capacity: 15 },
+        { name: "Drop-in", price: 10, description: "Non-member drop-in", capacity: 5  },
+      ];
+      for (const v of toCreate) {
+        const existing = await prisma.workshopPriceVariation.findFirst({
+          where: { workshopId: workshop.id, name: v.name },
+        });
+        const record = existing
+          ? existing
+          : await prisma.workshopPriceVariation.create({
+              data: { workshopId: workshop.id, ...v },
+            });
+        if (!existing) console.log(`    + "${v.name}"`);
+        priceVariations.push(record);
+      }
+    }
+  }
+  // If hasPriceVariations is false, priceVariations stays [] and no user gets one
+
+  // ── Determine next connectId (for multi-day grouping) ───────────────────────
+  let nextConnectId = 1;
+  if (DAYS_PER_SESSION > 1) {
+    const maxRow = await prisma.workshopOccurrence.findFirst({
+      where: { connectId: { not: null } },
+      orderBy: { connectId: "desc" },
+      select: { connectId: true },
+    });
+    nextConnectId = (maxRow?.connectId ?? 0) + 1;
+  }
+
+  // ── Create occurrence sessions ───────────────────────────────────────────────
+  const now = new Date();
+  console.log("\nCreating occurrence sessions...");
+
+  // sessions[i] = array of occurrences for session i
+  const sessions: Array<{ id: number; startDate: Date }[]> = [];
+
+  for (let s = 0; s < SESSION_OFFSETS.length; s++) {
+    const { daysAgo, startH } = SESSION_OFFSETS[s];
+    const connectId = DAYS_PER_SESSION > 1 ? nextConnectId + s : null;
+    const sessionOccs: { id: number; startDate: Date }[] = [];
+
+    for (let d = 0; d < DAYS_PER_SESSION; d++) {
+      const startDate = new Date(now);
+      startDate.setDate(startDate.getDate() - daysAgo + d); // consecutive days
+      startDate.setHours(startH, 0, 0, 0);
+      const endDate = new Date(startDate);
+      endDate.setHours(startH + SESSION_DURATION_H, 0, 0, 0);
+
+      const occ = await prisma.workshopOccurrence.create({
+        data: {
+          workshopId: workshop.id,
+          startDate,
+          endDate,
+          status: "past",
+          ...(connectId !== null ? { connectId } : {}),
+        },
+      });
+      sessionOccs.push({ id: occ.id, startDate });
+    }
+
+    const dayLabel = DAYS_PER_SESSION > 1
+      ? `day 1: ${sessionOccs[0].startDate.toISOString().slice(0, 10)} … day ${DAYS_PER_SESSION}: ${sessionOccs.at(-1)!.startDate.toISOString().slice(0, 10)}  [connectId=${connectId}]`
+      : sessionOccs[0].startDate.toISOString().slice(0, 10);
+    console.log(`  Session ${s + 1}: ${dayLabel}  (occ IDs: ${sessionOccs.map((o) => o.id).join(", ")})`);
+    sessions.push(sessionOccs);
+  }
+
+  // ── Hash password once ───────────────────────────────────────────────────────
+  const hashedPassword = await bcrypt.hash("password", 10);
+
+  // ── Create users and register them ──────────────────────────────────────────
+  console.log("\nRegistering users...");
+  let registered = 0;
+
+  for (let i = 0; i < USER_SPECS.length; i++) {
+    const spec = USER_SPECS[i];
+    const sessionIdx = Math.floor(i / USERS_PER_SESSION);
+    const sessionOccs = sessions[sessionIdx];
+    const email = `seed.${spec.firstName.toLowerCase()}.${spec.lastName.toLowerCase()}@scripttest.local`;
+
+    const user = await prisma.user.upsert({
+      where: { email },
+      update: {},
+      create: {
+        email,
+        password: hashedPassword,
+        firstName: spec.firstName,
+        lastName: spec.lastName,
+        phone: "5555555555",
+        dateOfBirth: "1990-01-01",
+        emergencyContactName: "Emergency Contact",
+        emergencyContactPhone: "5551234567",
+        emergencyContactEmail: "emergency@scripttest.local",
+        mediaConsent: true,
+        dataPrivacy: true,
+        communityGuidelines: true,
+        operationsPolicy: true,
+        roleUserId: 1,
+      },
+    });
+
+    // Registration date = N days before the first occurrence of the session
+    const registrationDate = new Date(sessionOccs[0].startDate);
+    registrationDate.setDate(registrationDate.getDate() - spec.regDaysBefore);
+
+    // Resolve price variation — only if workshop actually has them
+    const priceVariationId =
+      workshop.hasPriceVariations && spec.usePriceVar !== undefined
+        ? (priceVariations[spec.usePriceVar]?.id ?? null)
+        : null;
+
+    // Register for EVERY occurrence in the session (multi-day: one row per day)
+    for (const occ of sessionOccs) {
+      await prisma.userWorkshop.upsert({
+        where: { userId_occurrenceId: { userId: user.id, occurrenceId: occ.id } },
+        update: { result: spec.result },
+        create: {
+          userId: user.id,
+          workshopId: workshop.id,
+          occurrenceId: occ.id,
+          result: spec.result,
+          date: registrationDate,
+          ...(priceVariationId ? { priceVariationId } : {}),
+        },
+      });
+    }
+
+    const varName = priceVariationId
+      ? priceVariations.find((v) => v.id === priceVariationId)?.name
+      : null;
+    const occLabel = sessionOccs.length > 1
+      ? `${sessionOccs.length} occs`
+      : `occ ${sessionOccs[0].id}`;
+    console.log(
+      `  ${spec.firstName.padEnd(8)} ${spec.lastName.padEnd(10)}` +
+      `  session ${sessionIdx + 1}  ${occLabel}` +
+      `  result: ${spec.result.padEnd(10)}` +
+      (varName ? `  [${varName}]` : "")
+    );
+    registered++;
+  }
+
+  // ── Summary ──────────────────────────────────────────────────────────────────
+  const totalOccs = sessions.reduce((sum, s) => sum + s.length, 0);
+  console.log(
+    `\n✓  ${registered} users · ${totalOccs} occurrence${totalOccs > 1 ? "s" : ""} across ${sessions.length} sessions`
+  );
+  console.log(`\nView the page:`);
+  console.log(`  /dashboard/admin/workshop/${workshop.id}/users`);
+
+  console.log("\nDate filter values (first day of each session):");
+  sessions.forEach((occs, i) => {
+    const iso = occs[0].startDate.toISOString().slice(0, 10);
+    console.log(`  Session ${i + 1}: ${iso}`);
+  });
+
+  if (!isOrientation) {
+    console.log(
+      "\nNote: this is a regular workshop — the Result column shows plain text, not a dropdown."
+    );
+  }
+  if (DAYS_PER_SESSION > 1) {
+    console.log(
+      `\nNote: multi-day — each row in the table expands to show ${DAYS_PER_SESSION} individual day results.`
+    );
+  }
+  if (!workshop.hasPriceVariations) {
+    console.log(
+      "\nNote: hasPriceVariations=false — Price Variation column will show N/A for all rows."
+    );
+  }
+}
+
+main()
+  .then(() => prisma.$disconnect())
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Adds filtering and sorting controls to the **Users Registered for [Workshop]** admin page (`/dashboard/admin/workshop/:workshopId/users`), making it easier to manage orientation cohorts and track registration outcomes.

## Changes

### Filters
- **Result filter** — dropdown to show only registrations with a specific outcome: All / Passed / Failed / Pending / Cancelled
- **Date filter** — date picker that filters by occurrence date, allowing admins to isolate everyone who attended a specific session. A **Clear** button appears when a date is active.
- **Clear filters** button appears when any filter is active

### Sort
- Sort by **Last Name (A–Z)**, **First Name (A–Z)**, **Registration Date**, or **Occurrence Date(s)**
- Ascending / descending toggle

### Behaviour across all workshop types
- **Single-day orientations & workshops** — filters and sort work as expected
- **Multi-day workshops** — registrations are grouped by `connectId`; the date filter matches a group if *any* day in the series falls on the selected date; the result filter evaluates the group's effective result across all days (a group is "passed" only when every non-cancelled day passes)
- **Price variations** — respected in all filter/sort paths
- **Pass All** — already scoped to the filtered list, so filtering to "Pending" on a specific date then clicking Pass All bulk-passes only that cohort

### Other
- Updated `seed.ts` to use relative occurrence dates so seeded workshops always appear upcoming
- Added `test-scripts/seed-orientation-registrations.ts` — populates any workshop with 20 test users across 5 past sessions with varied results; supports multi-day via `--days=N`