### PR TITLE
feat: Role Level filter, Membership filter overhaul, and expanded seed fixtures in User Management

### DIFF
--- a/app/routes/dashboard/adminsettings.tsx
+++ b/app/routes/dashboard/adminsettings.tsx
@@ -2740,6 +2740,7 @@ export default function AdminSettings() {
 
   // User table filters
   const [adminStatusFilter, setAdminStatusFilter] = useState<string[]>([]);
+  const [roleLevelFilter, setRoleLevelFilter] = useState<number[]>([]);
   const [membershipFilter, setMembershipFilter] = useState<string[]>([]);
   const [doorAccessFilter, setDoorAccessFilter] = useState<string[]>([]);
 
@@ -3100,10 +3101,21 @@ export default function AdminSettings() {
         if (!adminStatusFilter.includes(userAdminStatus)) return false;
       }
 
-      // Membership filter
+      // Role Level filter
+      if (roleLevelFilter.length > 0) {
+        if (!roleLevelFilter.includes(user.roleLevel)) return false;
+      }
+
+      // Membership filter — classifies by actual paid subscription status
       if (membershipFilter.length > 0) {
-        const userMembershipStatus =
-          user.membershipStatus === "revoked" ? "Revoked" : "Active";
+        let userMembershipStatus: string;
+        if (user.membershipStatus === "revoked") {
+          userMembershipStatus = "Access Revoked";
+        } else if (user.hasRevocableMembership) {
+          userMembershipStatus = "Active Subscription";
+        } else {
+          userMembershipStatus = "No Subscription";
+        }
         if (!membershipFilter.includes(userMembershipStatus)) return false;
       }
 
@@ -3130,7 +3142,7 @@ export default function AdminSettings() {
 
       return true;
     });
-  }, [users, adminStatusFilter, membershipFilter, doorAccessFilter]);
+  }, [users, adminStatusFilter, roleLevelFilter, membershipFilter, doorAccessFilter]);
 
   // Get unique values for filter options
   const adminStatusOptions = useMemo(() => {
@@ -3143,14 +3155,28 @@ export default function AdminSettings() {
   }, [users]);
 
   const membershipOptions = useMemo(() => {
-    const revoked = users.filter(
+    const accessRevoked = users.filter(
       (u) => u.membershipStatus === "revoked"
     ).length;
-    const active = users.length - revoked;
+    const activeSubscription = users.filter(
+      (u) => u.membershipStatus !== "revoked" && u.hasRevocableMembership
+    ).length;
+    const noSubscription = users.filter(
+      (u) => u.membershipStatus !== "revoked" && !u.hasRevocableMembership
+    ).length;
     return [
-      { value: "Revoked", count: revoked },
-      { value: "Active", count: active },
+      { value: "Active Subscription", count: activeSubscription },
+      { value: "No Subscription", count: noSubscription },
+      { value: "Access Revoked", count: accessRevoked },
     ];
+  }, [users]);
+
+  const roleLevelOptions = useMemo(() => {
+    const counts: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0 };
+    users.forEach((u) => {
+      if (u.roleLevel >= 1 && u.roleLevel <= 4) counts[u.roleLevel]++;
+    });
+    return [1, 2, 3, 4].map((level) => ({ value: level, count: counts[level] }));
   }, [users]);
 
   const doorAccessOptions = useMemo(() => {
@@ -3232,11 +3258,11 @@ export default function AdminSettings() {
     {
       header: "Role Level",
       id: "roleLevel",
+      accessorFn: (row) => row.roleLevel,
       cell: ({ row }: { row: { original: UserRow } }) => (
         <RoleControl user={row.original} />
       ),
       size: 200,
-      enableSorting: false,
     },
     {
       header: "Admin Status",
@@ -3257,16 +3283,21 @@ export default function AdminSettings() {
     {
       header: "Membership",
       id: "membership",
-      accessorFn: (row) =>
-        row.membershipStatus === "revoked" ? "Revoked" : "Active",
+      accessorFn: (row) => {
+        if (row.membershipStatus === "revoked") return "Access Revoked";
+        if (row.hasRevocableMembership) return "Active Subscription";
+        return "No Subscription";
+      },
       cell: ({ row }: { row: { original: UserRow } }) => (
         <MembershipControl user={row.original} />
       ),
       size: 200,
       enableSorting: false,
       filterFn: (row, id, value) => {
-        const status =
-          row.original.membershipStatus === "revoked" ? "Revoked" : "Active";
+        let status: string;
+        if (row.original.membershipStatus === "revoked") status = "Access Revoked";
+        else if (row.original.hasRevocableMembership) status = "Active Subscription";
+        else status = "No Subscription";
         return value.includes(status);
       },
     },
@@ -4259,6 +4290,83 @@ export default function AdminSettings() {
                                 variant="ghost"
                                 size="sm"
                                 onClick={() => setAdminStatusFilter([])}
+                                className="w-full"
+                              >
+                                Clear
+                              </Button>
+                            )}
+                          </div>
+                        </PopoverContent>
+                      </Popover>
+
+                      {/* Role Level Filter */}
+                      <Popover>
+                        <PopoverTrigger asChild>
+                          <Button variant="outline">
+                            <FilterIcon
+                              className="-ms-1 opacity-60"
+                              size={16}
+                              aria-hidden="true"
+                            />
+                            Role Level
+                            {roleLevelFilter.length > 0 && (
+                              <span className="-me-1 inline-flex h-5 max-h-full items-center rounded border bg-background px-1 font-[inherit] text-[0.625rem] font-medium text-muted-foreground/70">
+                                {roleLevelFilter.length}
+                              </span>
+                            )}
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent
+                          className="w-auto min-w-36 p-3"
+                          align="start"
+                        >
+                          <div className="space-y-3">
+                            <div className="text-xs font-medium text-muted-foreground">
+                              Filter by Role Level
+                            </div>
+                            <div className="space-y-3">
+                              {roleLevelOptions.map((option) => (
+                                <div
+                                  key={option.value}
+                                  className="flex items-center gap-2"
+                                >
+                                  <Checkbox
+                                    id={`role-level-${option.value}`}
+                                    checked={roleLevelFilter.includes(
+                                      option.value
+                                    )}
+                                    onCheckedChange={(checked: boolean) => {
+                                      if (checked) {
+                                        setRoleLevelFilter([
+                                          ...roleLevelFilter,
+                                          option.value,
+                                        ]);
+                                      } else {
+                                        setRoleLevelFilter(
+                                          roleLevelFilter.filter(
+                                            (f) => f !== option.value
+                                          )
+                                        );
+                                      }
+                                    }}
+                                  />
+                                  <Label
+                                    htmlFor={`role-level-${option.value}`}
+                                    className="flex grow justify-between gap-2 font-normal cursor-pointer"
+                                  >
+                                    Level {option.value}{" "}
+                                    <span className="ms-2 text-xs text-muted-foreground">
+                                      {option.count}
+                                    </span>
+                                  </Label>
+                                </div>
+                              ))}
+                            </div>
+                            {roleLevelFilter.length > 0 && (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setRoleLevelFilter([])}
                                 className="w-full"
                               >
                                 Clear

--- a/docs/msyk-overview.md
+++ b/docs/msyk-overview.md
@@ -295,6 +295,19 @@ The MSYK Membership Management System is a comprehensive platform for managing m
 - User sync status display and retry functionality
 - Integration status indicator (shows if Brivo credentials are configured)
 
+**User Management Table (Admin Settings → User Settings tab):**
+- Lists all registered users with columns: First Name, Last Name, Training Card User Number, Email, Phone Number, Role Level, Admin Status, Membership, Door Access
+- **Admin Status filter**: show only Admins or non-admins
+- **Role Level filter**: filter to users at specific role level(s) (1, 2, 3, or 4); each option shows the live count of users at that level
+- **Membership filter**: filter by paid subscription status — three mutually exclusive categories:
+  - `"Active Subscription"` — access not revoked AND has at least one `UserMembership` record with status `active`, `ending`, or `cancelled`
+  - `"No Subscription"` — access not revoked AND no active membership record on file (registered but never subscribed)
+  - `"Access Revoked"` — `membershipStatus === "revoked"` (admin manually revoked, regardless of subscription records)
+- **Door Access filter**: filter by Brivo provisioning status (Disabled, Provisioned, Checking, Registered, Pending Sync, Sync Error)
+- **Name/email search**: global search across first name, last name, and email
+- **Role Level column**: sortable ascending/descending by clicking the column header
+- All active filters are ANDed — a user must satisfy every selected filter to appear
+
 **Admin Functions:**
 - User management (role assignment, `allowLevel4` flag, membership revocation/unrevocation)
 - Workshop CRUD operations
@@ -1160,7 +1173,8 @@ The following acceptance criteria should be manually tested by QA in the applica
 | ---- | **Events:** Delete All Occurrences to Multi-day Workshop/Orientation With Price Variation; Occurrence Showcase in Google Calendar | Go to edit workshop and then /dashboard/events | When admin deletes all occurrences, the deleted occurrences should not show up anymore (if no one has registered since you cannot add dates anymore if a user has registered) but you must add at least one occurrence or more and those occurrence added will show on the calendar with Name, Location, Description, Pricing Options, Type, Capacity, That it is Part of a Multi-day Series, Register Link (in localhost or prod website) | `NA` | `TODO/TOFIX`
 | ---- | **Admin Settings:** Workshop Past Workshop Visibility | Go to admin settings | Workshops that have ALL days past the N days, where N is the value of Past Workshop Visibility will not show in the workshop past events. If at least one of the workshops are not past the N days, then it will show | `NA` | `12/05/2025`
 | ---- | **Admin Settings:** Workshop Registration Cutoffs | Go to admin settings | Be able to set the registration cutoff for workshops. For regular workshop, it is based on the individual date. For multi-day workshops, it is based on the first date in the multi-day set | `NA` | `12/05/2025`
-| ---- | **Admin Settings:** User Managment Filters | Go to admin settings | Be able to filter users by admin status, membership, and door access | `NA` | `12/05/2025`
+| ---- | **Admin Settings:** User Managment Filters | Go to admin settings | Be able to filter users by admin status, role level, membership, and door access; membership options are "Active Subscription" (allowed + has active membership record), "No Subscription" (allowed + no membership record), and "Access Revoked" (revoked by admin); role level filter shows counts per level (1–4); all filters are ANDed | `NA` | `06/01/2026`
+| ---- | **Admin Settings:** User Management Role Level Sort | Go to admin settings | The Role Level column should be sortable ascending/descending by clicking the column header | `NA` | `06/01/2026`
 | ---- | **Admin Settings:** User Managment Filter by First or Last Name | Go to admin settings | Be able to filter users by first or last name | `NA` | `12/05/2025`
 | ---- | **Admin Settings:** User Managment Filter by Toggle Columns View | Go to admin settings | Be able to toggle columns using Views | `NA` | `12/05/2025`
 | ---- | **Admin Settings:** User Managment Allow Level 4 | Go to admin settings | Be able to allow level 4 for a user once they are level >= 3 | `NA` | `12/05/2025`

--- a/seed.ts
+++ b/seed.ts
@@ -15,8 +15,9 @@ async function main() {
   await prisma.user.deleteMany();
   await prisma.membershipPlan.deleteMany();
   await prisma.roleUser.deleteMany();
-  await prisma.workshop.deleteMany();
+  await prisma.workshopPriceVariation.deleteMany();
   await prisma.workshopOccurrence.deleteMany();
+  await prisma.workshop.deleteMany();
   await prisma.equipment.deleteMany();
 
   await prisma.$executeRaw`ALTER SEQUENCE "User_id_seq" RESTART WITH 1`;
@@ -26,6 +27,7 @@ async function main() {
   await prisma.$executeRaw`ALTER SEQUENCE "WorkshopOccurrence_id_seq" RESTART WITH 1`;
   await prisma.$executeRaw`ALTER SEQUENCE "Equipment_id_seq" RESTART WITH 1`;
   await prisma.$executeRaw`ALTER SEQUENCE "AdminSettings_id_seq" RESTART WITH 1`;
+  await prisma.$executeRaw`ALTER SEQUENCE "WorkshopPriceVariation_id_seq" RESTART WITH 1`;
 
   const hashedPassword = await bcrypt.hash("password", 10);
   const now = new Date();
@@ -200,6 +202,114 @@ async function main() {
           "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
         registrationCutoff: 60,
       },
+      // ID 7 — Workshop: Regular (single-day, no price variations)
+      {
+        name: "Workshop — Regular Single-Day",
+        description:
+          "A standard single-session workshop. One day, one time slot, flat pricing.",
+        price: 35.0,
+        location: "Makerspace YK — Digital Lab",
+        capacity: 10,
+        type: "workshop",
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 60,
+      },
+      // ID 8 — Workshop: Multi-Day (multiple occurrences linked by connectId, no price variations)
+      {
+        name: "Workshop — Multi-Day",
+        description:
+          "A multi-session workshop spanning three consecutive days. All days are required; registrations cover all linked sessions.",
+        price: 75.0,
+        location: "Makerspace YK — Shopspace",
+        capacity: 8,
+        type: "workshop",
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 60,
+      },
+      // ID 9 — Workshop: Regular with Price Variations (single-day, has member/non-member tiers)
+      {
+        name: "Workshop — Regular Single-Day with Price Variations",
+        description:
+          "A single-day workshop with tiered pricing. Members pay a reduced rate; non-members pay standard pricing.",
+        price: 0.0,
+        location: "Makerspace YK — Hackspace",
+        capacity: 12,
+        type: "workshop",
+        hasPriceVariations: true,
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 60,
+      },
+      // ID 10 — Workshop: Multi-Day with Price Variations
+      {
+        name: "Workshop — Multi-Day with Price Variations",
+        description:
+          "A multi-day workshop spanning three sessions with tiered member/non-member pricing.",
+        price: 0.0,
+        location: "Makerspace YK — Digital Lab",
+        capacity: 10,
+        type: "workshop",
+        hasPriceVariations: true,
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 60,
+      },
+      // ID 11 — Orientation: Regular (single-day, no price variations)
+      {
+        name: "Orientation — Regular Single-Day",
+        description:
+          "A standard single-session orientation. One day, one time slot, flat (free) pricing.",
+        price: 0.0,
+        location: "Makerspace YK",
+        capacity: 20,
+        type: "orientation",
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 30,
+      },
+      // ID 12 — Orientation: Multi-Day (multiple occurrences linked by connectId)
+      {
+        name: "Orientation — Multi-Day",
+        description:
+          "A multi-session orientation spanning two consecutive days. Both days are required to complete the orientation.",
+        price: 0.0,
+        location: "Makerspace YK",
+        capacity: 15,
+        type: "orientation",
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 30,
+      },
+      // ID 13 — Orientation: Regular with Price Variations (single-day, has student/standard tiers)
+      {
+        name: "Orientation — Regular Single-Day with Price Variations",
+        description:
+          "A single-day orientation with tiered pricing. Students pay a reduced fee; standard pricing otherwise.",
+        price: 0.0,
+        location: "Makerspace YK — Shopspace",
+        capacity: 12,
+        type: "orientation",
+        hasPriceVariations: true,
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 30,
+      },
+      // ID 14 — Orientation: Multi-Day with Price Variations
+      {
+        name: "Orientation — Multi-Day with Price Variations",
+        description:
+          "A two-day orientation with tiered student/standard pricing. Both days required.",
+        price: 0.0,
+        location: "Makerspace YK",
+        capacity: 15,
+        type: "orientation",
+        hasPriceVariations: true,
+        cancellationPolicy:
+          "Can't make it? Email info@makerspaceyk.com. Full refunds are only available if canceled within 48 hours before the scheduled start time of the workshop/orientation.",
+        registrationCutoff: 30,
+      },
     ],
   });
 
@@ -267,6 +377,30 @@ async function main() {
       startDate: addDays(now, -14),
       endDate: addDays(now, -14),
     },
+    // Workshop — Regular Single-Day (ID 7)
+    {
+      workshopId: 7,
+      startDate: addDays(now, 8),
+      endDate: addDays(now, 8),
+    },
+    // Workshop — Regular Single-Day with Price Variations (ID 9)
+    {
+      workshopId: 9,
+      startDate: addDays(now, 11),
+      endDate: addDays(now, 11),
+    },
+    // Orientation — Regular Single-Day (ID 11)
+    {
+      workshopId: 11,
+      startDate: addDays(now, 6),
+      endDate: addDays(now, 6),
+    },
+    // Orientation — Regular Single-Day with Price Variations (ID 13)
+    {
+      workshopId: 13,
+      startDate: addDays(now, 16),
+      endDate: addDays(now, 16),
+    },
   ];
 
   // Set start/end times: each occurrence is 2 hours; past ones explicitly past status
@@ -285,6 +419,141 @@ async function main() {
 
   await prisma.workshopOccurrence.createMany({
     data: workshopOccurrencesData,
+  });
+
+  // Multi-day occurrences need connectId — create individually so the grouped IDs are consistent.
+  // connectId 1 → Workshop — Multi-Day (ID 8), 3 days
+  for (let day = 0; day < 3; day++) {
+    const start = addDays(now, 15 + day);
+    start.setHours(10, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(14, 0, 0, 0);
+    await prisma.workshopOccurrence.create({
+      data: {
+        workshopId: 8,
+        startDate: start,
+        endDate: end,
+        connectId: 1,
+        status: "active",
+      },
+    });
+  }
+
+  // connectId 2 → Workshop — Multi-Day with Price Variations (ID 10), 3 days
+  for (let day = 0; day < 3; day++) {
+    const start = addDays(now, 22 + day);
+    start.setHours(10, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(14, 0, 0, 0);
+    await prisma.workshopOccurrence.create({
+      data: {
+        workshopId: 10,
+        startDate: start,
+        endDate: end,
+        connectId: 2,
+        status: "active",
+      },
+    });
+  }
+
+  // connectId 3 → Orientation — Multi-Day (ID 12), 2 days
+  for (let day = 0; day < 2; day++) {
+    const start = addDays(now, 9 + day);
+    start.setHours(13, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(16, 0, 0, 0);
+    await prisma.workshopOccurrence.create({
+      data: {
+        workshopId: 12,
+        startDate: start,
+        endDate: end,
+        connectId: 3,
+        status: "active",
+      },
+    });
+  }
+
+  // connectId 4 → Orientation — Multi-Day with Price Variations (ID 14), 2 days
+  for (let day = 0; day < 2; day++) {
+    const start = addDays(now, 18 + day);
+    start.setHours(13, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(16, 0, 0, 0);
+    await prisma.workshopOccurrence.create({
+      data: {
+        workshopId: 14,
+        startDate: start,
+        endDate: end,
+        connectId: 4,
+        status: "active",
+      },
+    });
+  }
+
+  // Price variations for workshops with hasPriceVariations=true
+  await prisma.workshopPriceVariation.createMany({
+    data: [
+      // Workshop — Regular Single-Day with Price Variations (ID 9)
+      {
+        workshopId: 9,
+        name: "Member",
+        price: 20.0,
+        description: "Discounted rate for active MSYK members.",
+        capacity: 8,
+      },
+      {
+        workshopId: 9,
+        name: "Non-Member",
+        price: 40.0,
+        description: "Standard rate for non-members.",
+        capacity: 4,
+      },
+      // Workshop — Multi-Day with Price Variations (ID 10)
+      {
+        workshopId: 10,
+        name: "Member",
+        price: 50.0,
+        description: "Discounted multi-day rate for active MSYK members.",
+        capacity: 7,
+      },
+      {
+        workshopId: 10,
+        name: "Non-Member",
+        price: 90.0,
+        description: "Standard multi-day rate for non-members.",
+        capacity: 3,
+      },
+      // Orientation — Regular Single-Day with Price Variations (ID 13)
+      {
+        workshopId: 13,
+        name: "Student",
+        price: 0.0,
+        description: "Free for enrolled students with valid student ID.",
+        capacity: 8,
+      },
+      {
+        workshopId: 13,
+        name: "Standard",
+        price: 15.0,
+        description: "Standard orientation fee for community members.",
+        capacity: 4,
+      },
+      // Orientation — Multi-Day with Price Variations (ID 14)
+      {
+        workshopId: 14,
+        name: "Student",
+        price: 0.0,
+        description: "Free two-day orientation for enrolled students.",
+        capacity: 10,
+      },
+      {
+        workshopId: 14,
+        name: "Standard",
+        price: 25.0,
+        description: "Standard fee for the two-day orientation.",
+        capacity: 5,
+      },
+    ],
   });
   await prisma.equipment.createMany({
     data: [


### PR DESCRIPTION
## What's changing

### Admin Settings — User Management table

**New: Role Level filter**

A new filter button in the User Management table lets admins narrow the list to users at one or more specific role levels (1–4). Each option shows a live count of users at that level. The filter works alongside the existing Admin Status, Membership, and Door Access filters — all active filters are ANDed.

**New: Role Level column sorting**

The Role Level column is now sortable. Clicking the column header toggles ascending/descending order, making it easy to scan users grouped by level without needing to apply a filter.

**Updated: Membership filter categories**

The old filter had two options — "Active" and "Revoked" — where "Active" meant any user whose access hadn't been manually revoked, including users who registered but never paid. This made it impossible to distinguish paying subscribers from non-paying registered users.

The filter now has three mutually exclusive categories:

| Category | Criteria |
|---|---|
| **Active Subscription** | Access not revoked + has at least one `UserMembership` record with status `active`, `ending`, or `cancelled` |
| **No Subscription** | Access not revoked + no active membership record on file |
| **Access Revoked** | `membershipStatus === "revoked"` (manually revoked by admin) |

### Seed script

- Added 8 new workshop/orientation fixtures covering every type combination: regular single-day, multi-day, with price variations, without price variations — for both workshop and orientation types
- Added corresponding occurrences and multi-day occurrence groups (via `connectId`)
- Added price variation records for the hasPriceVariations workshops/orientations
- Fixed deletion order to delete `WorkshopPriceVariation` records before `Workshop` records (referential integrity)
- Added `WorkshopPriceVariation_id_seq` sequence reset