### PR TITLE
fix: close registration cutoff bypass and correct doc drift

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -41,6 +41,7 @@ Notes for using it here:
 - `npm run dev` runs both the client and the cron server; the cron server is what flips workshop occurrence status, so start both when timing matters
 - You need a seeded database to log in — `npx tsx seed.ts` (requires `NODE_ENV=development`)
 - Chromium is already installed locally. If it is ever missing, `npx playwright install chromium`
+- The server drops page snapshots and console logs into `.playwright-mcp/` as you drive it. That directory is gitignored — do not commit it
 - This is for **interactive verification**, not an automated test suite. Regression tests belong in `tests/` under Jest
 
 ---
@@ -53,14 +54,18 @@ Custom slash commands defined as markdown files. Invoke them in Claude Code by t
 
 **File:** `commands/read-docs.md`
 
-Onboards Claude to the codebase at the start of a conversation by reading the docs *and* the source, then reporting where they disagree. Use this when starting fresh work on the repo.
+Orients Claude in the codebase at the start of a conversation, cheaply. Use this when starting fresh work on the repo.
+
+It is explicitly budgeted: **under 10% of the context window**. An earlier version read every markdown and all ~52,000 lines of source into the main context — it produced an excellent summary and left almost nothing to actually work with. The current version keeps the coverage and moves the cost off the main thread.
 
 What it does:
-- Enumerates every markdown in the repo with `find`, then reads them all in full — the three primary docs, both folder indexes (`docs/README.md`, `docs/implementations/README.md`), and all five `.claude` files
-- Reads the Prisma schema, every model, service, util, config, `entry.server.ts`, `seed.ts`, `package.json`, `app/routes.ts`, and every route file
-- Skips exactly two things, deliberately: the frozen write-ups in `docs/implementations/` (reading them builds a false picture of current behavior) and the ~12,700-line Brivo API snapshot (read on demand instead, so it does not eat the context needed for the source)
-- Verifies specific high-risk claims against the code — cron schedules, session behavior, role level logic, seed guard, Stripe sync hooks, Brivo degradation, `AdminSettings` keys, route map completeness, unique constraints, whether documented functions are actually exported
-- Reports a verified understanding, an explicit list of discrepancies found (or states there were none), and which markdowns it skipped and why
+- **Phase 0 — orientation.** Skips `CLAUDE.md` (already auto-loaded), reads `tests/README.md` and `.claude/README.md` in full, enumerates every markdown with `find`, and indexes `README.md` / `MSYK-OVERVIEW.md` by heading rather than reading them cover to cover — so it can jump to the right section when a task needs it
+- **Phase 1 — structural map.** A handful of `grep`/`sed` commands that yield the data model, the full route table, every exported model/service function, cron schedules, env vars, and `AdminSettings` keys — the shape of the system for a fraction of the tokens the source costs
+- **Phase 2 — delegated deep reading.** Up to three `Explore` subagents in parallel (business logic, request layer, auth/config), each capped at a 40-line brief. The ~50,000 lines are read in *their* context; only the briefs reach the main one. Fewer subagents when the task is narrow
+- **Phase 3 — mechanical verification.** Four cheap shell checks: every route file registered, every route in the README map, documented functions actually exported, referenced paths exist. It does **not** audit the prose claim by claim — `/update-all-docs` keeps docs honest as code changes, and a full audit is something you ask for explicitly
+- **Phase 4 — a report under ~40 lines**, ending with an explicit list of what it did *not* read
+
+Deliberate omissions, in the command itself: the frozen write-ups in `docs/implementations/` (reading them builds a false picture of current behavior), the ~12,700-line Brivo API snapshot (read on demand), and the JSX of the six largest route files (their loaders and actions are read; their markup is not).
 
 ### /update-all-docs
 

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -17,7 +17,7 @@ Read the diff. Do not commit changes you have not read.
 
 **Run `npm test` and `npm run typecheck` before the first commit.**
 
-- `npm test` — the suite is fully green (26 suites / 363 tests). A failure after your change is a regression you introduced; fix it before committing rather than committing over it
+- `npm test` — the suite is fully green (27 suites / 372 tests). A failure after your change is a regression you introduced; fix it before committing rather than committing over it
 - `npm run typecheck` — regenerates React Router types and type-checks the project. Three pre-existing errors in `old/webhooks.server.ts` are known and unrelated
 
 If either fails for a reason genuinely unrelated to your change, say so explicitly and continue.
@@ -32,7 +32,7 @@ Every implementation here follows **implement → test → verify end to end**, 
 - **Never commit `.env`.** It is gitignored; if it appears in `git status`, stop and tell the user
 - **Never commit `.claude/settings.local.json`** — personal machine settings, not shared config
 - **Do commit `.claude/README.md` and `.claude/commands/*.md`.** These are shared team configuration and are tracked in this repo. `/update-all-docs` maintains them, so they legitimately change alongside code
-- Build artifacts, `node_modules/`, `logs/*`, `public/images_custom`, and `public/uploads/issues/*` are gitignored — if any shows up in `git status`, something is wrong; tell the user rather than committing it
+- Build artifacts, `node_modules/`, `logs/*`, `public/images_custom`, `public/uploads/issues/*`, and `.playwright-mcp/` (Playwright MCP session snapshots and console logs) are gitignored — if any shows up in `git status`, something is wrong; tell the user rather than committing it
 
 ### Files that must travel together
 

--- a/.claude/commands/read-docs.md
+++ b/.claude/commands/read-docs.md
@@ -1,160 +1,125 @@
-You are onboarding yourself to this codebase at the start of a conversation. Your goal is to build an accurate, verified mental model of the system — not to read docs and accept them at face value, but to read the actual source code and confirm what is real.
+You are orienting yourself in this codebase at the start of a conversation. The goal is a **working** mental model — accurate about the things that bite, and honest about what you have not looked at — reached without spending the context budget the actual task needs.
 
-Do not summarize as you go. Do not report progress mid-way. Read everything first, then produce one honest summary at the end.
+**Budget: aim to finish this in well under 10% of your context window.** If you find yourself reading a third large source file directly, stop — that is what the subagents in Phase 2 are for.
+
+The old version of this command read every markdown and all ~52,000 lines of source into the main context. That produced a great summary and left almost no room to do the work. Do not do that. The rule now is:
+
+> **Read cheap, structured things yourself. Delegate expensive, unstructured reading to subagents. Read a specific file in full only when the task actually touches it.**
 
 ---
 
-## Phase 1 — Read every relevant markdown in full
+## Phase 0 — Orientation (do this yourself, it is cheap)
 
-Do not work from the list below alone — enumerate the markdowns that actually exist, so a file added since this command was written cannot be missed:
+`CLAUDE.md` is already in your context — it is loaded automatically. **Do not read it again.**
+
+Read these two in full. They are short and they govern how you are expected to work:
+
+- `tests/README.md` — test layout, fixture conventions, the import-ordering rule, the failure modes that have actually bitten here
+- `.claude/README.md` — the slash commands and MCP servers available in this repo
+
+Then enumerate what else exists, so a file added since this command was written cannot be missed:
 
 ```bash
 find . -name "*.md" -not -path "./node_modules/*" -not -path "./.git/*" | sort
 ```
 
-Read **every file that command returns in full**, with exactly two carve-outs, both explained below. As of writing that means:
+Do **not** read `README.md` or `MSYK-OVERVIEW.md` cover to cover. Instead, index them so you can jump straight to the right section later:
 
-**Primary docs — the maintained description of the system:**
-- `README.md`
-- `CLAUDE.md`
-- `MSYK-OVERVIEW.md`
-
-**Folder indexes — what else exists and whether it is maintained:**
-- `tests/README.md` — the test suite: layout, fixture conventions, and the implement → test → verify workflow you are expected to follow
-- `docs/README.md`
-- `docs/implementations/README.md`
-
-**Claude Code configuration — the workflows available to you in this repo:**
-- `.claude/README.md`
-- `.claude/commands/read-docs.md` (this file)
-- `.claude/commands/update-all-docs.md`
-- `.claude/commands/commit.md`
-- `.claude/commands/make-pr.md`
-
-### The two carve-outs
-
-**1. `docs/implementations/*.md` (except its `README.md`) — skip.** These are frozen point-in-time records of a single past implementation. They are deliberately not maintained, so reading them builds a *false* picture of current behavior. Read one only if you are specifically investigating the history of that feature, and never treat it as a description of how the system works now. Do read `docs/implementations/README.md`, which explains the folder.
-
-**2. `docs/apidocs.brivo.com_*.md` — do not read in Phase 1.** It is a ~12,700-line vendor API snapshot; reading it here would consume the context budget Phase 2 needs for the source. Read it on demand, when you actually work on the Brivo door access integration. Note its existence and move on.
-
-### While reading
-
-Note any claims that need verification against the code (e.g. "cron runs every 15s", "emails stored as lowercase", "seed only runs in development"). You will verify these in Phase 2.
-
-Everything under `docs/` is reference material that may lag the code. When it disagrees with the source, the source wins, and that disagreement is **not** a discrepancy worth reporting — only the primary docs and the `.claude` files are held to being accurate.
-
----
-
-## Phase 2 — Read the source code in full
-
-Read every file listed below completely. If a file is too long to read in one call, read it in chunks — do not stop until you have read all of it.
-
-**Schema (read first — everything else references it):**
-- `prisma/schema.prisma`
-
-**Models (all of them):**
-- `app/models/user.server.ts`
-- `app/models/workshop.server.ts`
-- `app/models/equipment.server.ts`
-- `app/models/membership.server.ts`
-- `app/models/payment.server.ts`
-- `app/models/profile.server.ts`
-- `app/models/admin.server.ts`
-- `app/models/access_card.server.ts`
-- `app/models/accessLog.server.ts`
-- `app/models/issue.server.ts`
-
-**Services:**
-- `app/services/brivo.server.ts`
-- `app/services/access-control-sync.server.ts`
-- `app/services/stripe-sync.server.ts`
-
-**Utilities:**
-- `app/utils/session.server.ts`
-- `app/utils/db.server.ts`
-- `app/utils/email.server.ts`
-- `app/utils/googleCalendar.server.ts`
-- `app/utils/singleton.server.ts`
-
-**Config and logging:**
-- `app/config/access-control.ts`
-- `app/logging/logger.ts`
-
-**Server entry (cron jobs start here):**
-- `entry.server.ts`
-
-**Seed script:**
-- `seed.ts`
-
-**Root config:**
-- `package.json`
-- `app/routes.ts`
-- `vite.config.ts`
-- `tsconfig.json`
-- `components.json`
-- `.mcp.json` — MCP servers available to you in this repo (currently Playwright, for driving a real browser against the running app)
-
-**Routes — read all files in these directories:**
-
-Run this to get the full list:
 ```bash
-find app/routes -name "*.ts" -o -name "*.tsx" | sort
+grep -n '^#\{1,3\} ' README.md MSYK-OVERVIEW.md
 ```
 
-Then read every file in the list. Do not skip any route file.
+Treat that heading index as a table of contents. When a task touches memberships, you read the membership section then — not now.
+
+### Files you deliberately do not read
+
+- **`docs/implementations/*.md`** (except its `README.md`) — frozen point-in-time records of one past implementation. They are not maintained, so reading them builds a *false* picture of current behaviour. Open one only when investigating that feature's history.
+- **`docs/apidocs.brivo.com_*.md`** — a ~12,700-line vendor API snapshot. Read it on demand, when you actually work on the Brivo door access integration.
+- **The six largest route files** — `adminsettings.tsx` (~7.8k lines), `editworkshop.tsx` (~3.9k), `workshopdetails.tsx` (~2.5k), `addworkshop.tsx` (~2.3k), `profile.tsx` (~2.2k), `adminreports.tsx` (~1.7k). Their loaders and actions are worth reading when relevant; their JSX almost never is. Use `awk '/^export async function (loader|action)/,/^export default/'` to pull just the server logic.
 
 ---
 
-## Phase 3 — Verify the documentation against what you read
+## Phase 1 — Generate a structural map (cheap, high signal)
 
-Go through every factual claim in `README.md`, `CLAUDE.md`, and `MSYK-OVERVIEW.md` and check it against what you actually saw in the source files. Be honest. Do not rationalize discrepancies away.
+These commands produce a dense picture of the system for a tiny fraction of the tokens that reading the source costs. Run them and keep the output.
 
-Also check the `.claude` files, which must describe this repo accurately: does `.claude/README.md` list exactly the commands present in `.claude/commands/`, and do the file paths and doc names those commands reference still exist?
+```bash
+# Scripts, deps, and the shape of the data model
+sed -n '/"scripts"/,/}/p' package.json
+grep -n '^model \|^  @@unique\|^  @@index' prisma/schema.prisma
 
-Do **not** report `docs/implementations/*` or the Brivo API snapshot as out of date — they are not maintained against the code by design.
+# Every route path → file, in one table
+grep -oE 'route\("[^"]+", "[^"]+"' app/routes.ts | sed 's/route(//;s/"//g'
 
-Check at minimum:
+# The public surface of the business logic
+grep -rn '^export \(async \)\?\(function\|const\) ' app/models app/services app/utils app/config
 
-- Every command listed in CLAUDE.md and README.md — does it match `package.json` scripts?
-- Every `AdminSettings` key documented — does a matching string literal appear in the source? Are there keys in the source that the docs never mention?
-- Every cron job schedule — does it match the actual `node-cron` or `setInterval` call?
-- Every env var mentioned — does it actually appear in the source files?
-- Every model and field name — does it match `schema.prisma`?
-- Every route in the route map — does it exist in `app/routes.ts` and the route files?
-- Every model function listed — does it actually exist in the model file?
-- Session behavior (3-hour timeout, `loginTime` validation) — verified in `session.server.ts`?
-- Email case normalization — verified in `session.server.ts`?
-- Seed guard (NODE_ENV check) — verified in `seed.ts`?
-- Role level logic — verified in `user.server.ts`?
-- Stripe sync hooks — are they actually called from model create/update/delete functions?
-- Brivo integration — does it gracefully degrade when env vars are missing?
-- Every unique constraint claimed in the docs — does it actually exist in `schema.prisma`, or was it commented out?
-- Every documented model function — is it actually `export`ed, or is it an internal helper?
+# The things the docs most often get wrong
+grep -rn 'cron.schedule\|setInterval(' app/ entry.server.ts
+grep -rhoE 'process\.env\.[A-Z0-9_]+' app/ entry.server.ts seed.ts | sed 's/process\.env\.//' | sort -u
+grep -rhoE 'getAdminSetting\(\s*"[a-z0-9_]+"|key: "[a-z0-9_]+"' app/ | grep -oE '"[a-z0-9_]+"' | sort -u
+```
+
+Between the heading index and this map you now know *what exists and where*. That is enough to start most tasks.
 
 ---
 
-## Phase 4 — Report
+## Phase 2 — Delegate the deep reading to subagents
 
-After completing all three phases, produce a single report with these sections:
+Spawn these **in parallel**, in the background, as `Explore` agents. The point is that ~50k lines get read in *their* context and only a compact brief comes back to yours.
 
-### Verified Understanding
-A concise but complete summary of how the system actually works, based on what you read. Cover:
-- Tech stack and architecture
-- Auth and session behavior
-- Role level system and how it's calculated and synced
-- Cron jobs (exact schedules confirmed from code)
-- Workshop system (offer pattern, occurrence status, multi-day, prerequisites)
-- Equipment booking system
-- Membership system (billing, auto-renew, revocation)
-- Payment flow (Stripe Checkout vs Quick Checkout, GST)
-- Stripe Product Sync
-- Brivo and ESP32 door access (two separate systems)
-- Email system
-- Seed script behavior
-- AdminSettings keys and their defaults
+Give every one of them this instruction verbatim: **"Return at most 40 lines. Dense prose or bullets, no code blocks, no file dumps. Cite `file.ts:line` for anything specific. Report what the code actually does, not what you would expect it to do."**
 
-### Discrepancies Found
-List every place where the documentation says something that does not match the code. Be specific: quote the doc claim and describe what the code actually does. If you found none, say so explicitly.
+1. **Business logic** — read `app/models/*.server.ts` and `app/services/*.server.ts`. Report: how role levels are computed and synced; the membership lifecycle (subscribe, upgrade, downgrade, cancel, resubscribe, revoke) and what the billing cron does; workshop registration, capacity, and cancellation; equipment booking and refund rules; where Stripe and Brivo are called from.
+2. **Request layer** — read `app/routes/**`, prioritising every `loader` and `action`. Report: how each route authorises (`getRoleUser` / `getUser` / `getUserId` and what it redirects to on failure); which routes are admin-only; the payment routes and what they gate on; anything that looks inconsistent between sibling branches.
+3. **Auth, session, and config** — read `app/utils/session.server.ts`, `app/config/access-control.ts`, `entry.server.ts`, `seed.ts`, and `app/utils/email.server.ts` exports only. Report: exact session behaviour, the seed guard, what starts at boot, and the list of transactional emails with their triggers.
 
-### Ready
-One line confirming you have read all files and are ready to help with tasks in this codebase. Note explicitly which markdowns you skipped and why (the two carve-outs), so it is clear the omission was deliberate rather than an oversight.
+Wait for all three, then reconcile their briefs against the heading index from Phase 0. Where a brief and a doc disagree, **the code wins** — note it for Phase 4.
+
+If the task you were given is narrow and you already know which subsystem it touches, run only the subagent that covers it. Three is the maximum, not a quota.
+
+---
+
+## Phase 3 — Mechanical verification (seconds, near-zero tokens)
+
+These catch the drift that matters most and cost almost nothing. Run them:
+
+```bash
+# Every route file registered, and every route in the README map
+find app/routes -name "*.ts" -o -name "*.tsx" | sed 's|^app/||' | sort | while read f; do
+  grep -qF "\"$f\"" app/routes.ts || echo "UNREGISTERED ROUTE FILE: $f"; done
+grep -oE '"routes/[^"]+"' app/routes.ts | tr -d '"' | sort -u | while read f; do
+  grep -qF "$f" README.md || echo "MISSING FROM ROUTE MAP: $f"; done
+
+# Documented functions that are not actually exported
+grep -oE '`[a-z][A-Za-z0-9_]+\(\)`' README.md | tr -d '`()' | sort -u | while read fn; do
+  grep -rqE "export (async )?(function|const) $fn\b|export \{[^}]*\b$fn\b" app/ || echo "NOT EXPORTED: $fn"; done
+
+# Referenced paths that do not exist
+for doc in README.md CLAUDE.md MSYK-OVERVIEW.md tests/README.md .claude/README.md; do
+  grep -ohE '`?(app|prisma|tests|test-scripts|public|docs)/[A-Za-z0-9_./:*-]+' "$doc" \
+    | tr -d '`' | sed 's/[.,)]*$//' | sort -u | while read p; do
+        case "$p" in *'*'*) continue;; esac
+        [ -e "$p" ] || echo "$doc: MISSING PATH $p"
+      done; done
+```
+
+Three false positives are expected and are **not** findings: `redirect` (a framework import), `requireAuth` (README names it precisely to say it does not exist), and the "Need Jest Tests" paths in `MSYK-OVERVIEW.md` (tests not yet written, deliberately absent).
+
+**Do not** run a claim-by-claim audit of the prose. `/update-all-docs` keeps the docs honest as code changes; a full audit is something the user asks for explicitly.
+
+---
+
+## Phase 4 — Report, briefly
+
+Keep the whole report under ~40 lines. You are confirming readiness, not demonstrating effort.
+
+**How it works** — one tight paragraph per area you actually covered: stack, auth/session, role levels, cron jobs, workshops, equipment, memberships, payments, door access. Cite `file.ts:line` for anything a reader might want to check.
+
+**Worth knowing** — the gotchas that would cause you to write wrong code: constraints that are commented out, misspelled settings keys, values the schema comment describes wrongly, guards that exist in one branch but not its sibling.
+
+**Drift found** — anything Phase 2 or Phase 3 surfaced where a maintained doc disagrees with the code. Quote the claim, state what the code does. Say "none" if there was none. Do not report `docs/implementations/*` or the Brivo snapshot — they are unmaintained by design.
+
+**Not read** — name what you skipped: the two carve-outs above, the JSX of the large route files, and any subsystem whose subagent you chose not to run. Being explicit here is what makes the rest of the report trustworthy.
+
+Then stop and start the actual work. Read the specific files that work touches, when you touch them.

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ public/images_custom
 # Uploaded issue screenshots
 public/uploads/issues/*
 !public/uploads/issues/.gitkeep
+
+# Playwright MCP session artifacts (snapshots, console logs)
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ First decide which of the two cases you are in, because it changes step 2:
 1. **Implement** the feature
 2. **Add test files for it** under `tests/`, following the existing layout, and run them until they pass
 3. **Verify end to end with Playwright MCP** — drive the real flow in the browser and confirm it behaves as expected
-4. **Regress** — `npm test` must stay fully green (currently **26 suites / 363 tests**)
+4. **Regress** — `npm test` must stay fully green (currently **27 suites / 372 tests**)
 5. **Typecheck** — `npm run typecheck` (three pre-existing errors in `old/webhooks.server.ts` are known and unrelated)
 
 #### Case B — the change touches existing functionality
@@ -122,6 +122,7 @@ prisma/
 - **`EquipmentBooking` has no unique constraint on `slotId`** — `@@unique([slotId])` is commented out in `schema.prisma` so cancelled and new bookings can share a slot. Double-booking is prevented in application code, not the DB
 - **Occurrence status values** are `active` → `past` (set by the 1s cron) and `cancelled`; the `// "open", "closed", "cancelled"` comment in `schema.prisma` is stale
 - **`UserWorkshop.result`**: `passed` (schema default), `failed`, `pending`, `cancelled`
+- **The `payment.tsx` loader is the only server-side registration-cutoff gate.** Neither `quickCheckout()` nor `paymentsuccess.tsx` re-checks `Workshop.registrationCutoff`, so a loader branch that omits the check is bypassable by pasting the URL. All four workshop branches call `isPastRegistrationCutoff` today — if you add a fifth, add the check and a case to `tests/routes/dashboard/payment.cutoff.test.ts`
 - **Admin can move a registration** between occurrences of the same workshop via `moveUserWorkshopRegistration()` — single-day, active, in-capacity targets only
 
 ---

--- a/MSYK-OVERVIEW.md
+++ b/MSYK-OVERVIEW.md
@@ -125,10 +125,12 @@ The occurrence status job flips occurrences from `active` to `past` once their `
 - UI always treats `autoRenew` as `false` when no payment method is on file, regardless of DB value
 
 **Role Level Impact:**
-- Level 3: Active membership (standard plan)
-- Level 4: Active membership + `needAdminPermission` plan + `allowLevel4` flag
-- Level 2: Cancelled membership but completed orientation(s)
+- Level 3: Membership on file (standard plan) + completed orientation
+- Level 4: Membership on file + `needAdminPermission` plan + `allowLevel4` flag + completed orientation
+- Level 2: No membership on file, but completed orientation(s)
 - Level 1: No membership and no orientation
+
+**"Membership on file" means status `active`, `ending`, or `cancelled`** — `startRoleLevelSyncCron()` treats all three as still granting access, which is what keeps a cancelled member at Level 3 until their term actually lapses. Only when the daily billing cron flips the record to `inactive` (or it is deleted) does the user drop to Level 2/1. Brivo door access is stricter and uses `status === "active"` alone, so a cancelled Level 4 member keeps portal access but loses the physical door immediately.
 
 **Membership Revocation (Admin Action):**
 - Admin can revoke a user's membership access globally (ban status)
@@ -298,11 +300,20 @@ The occurrence status job flips occurrences from `active` to `past` once their `
 - Max equipment slots per day (key: `max_number_equipment_slots_per_day`, default: `"4"`)
 - Max equipment slots per week (key: `max_number_equipment_slots_per_week`, default: `"14"`)
 
-**Admin Settings Tabs:**
-- **General** — GST, visibility windows, planned closures
-- **Google Calendar** — Connect/disconnect via OAuth, select calendar from dropdown
-- **Brivo** — Access group configuration, webhook management (create/delete), user sync status and retry
-- **Stripe Products** — Bulk sync all workshops/membership plans/equipment to Stripe; "Clear & Re-sync" for environment switching; sync count display per category
+**Admin Settings Tabs** (the `TabsTrigger` values in `app/routes/dashboard/adminsettings.tsx`, in order):
+- **Workshop Settings** — workshop visibility days, past workshop visibility, per-workshop registration cutoffs
+- **User Settings** — user table with admin/role level/membership/door access filters, role level and `allowLevel4` controls, admin status, membership revoke/unrevoke, Brivo sync status and retry
+- **Volunteer Settings** — volunteer status management, volunteer hour approval, recently managed actions
+- **Equipment Settings** — equipment visibility days, Level 3 booking hours, Level 4 unavailable hours, max slots per day/week
+- **Planned Closures** — add and remove closure periods
+- **Cancelled Events** — workshop and equipment cancellations, refund eligibility, resolved toggle
+- **Miscellaneous Settings** — GST/HST percentage
+- **Integrations** — Google Calendar (connect/disconnect via OAuth, select calendar, timezone) **and** Brivo (access group, webhook subscription create/delete, integration status)
+- **Security & Access** — access token generation, access card lookup by UUID or email, card permissions
+- **Stripe Products** — bulk sync all workshops/membership plans/equipment to Stripe; "Clear & Re-sync" for environment switching; sync count display per category
+- **Other Settings** — placeholder
+
+Note there is no separate "General", "Google Calendar", or "Brivo" tab — GST lives under Miscellaneous Settings, and Google Calendar and Brivo are both cards inside Integrations.
 
 **Stripe Products Tab (Implemented):**
 - Links each item to a Stripe Product via `stripeProductId` — enables coupon restrictions to specific items
@@ -643,15 +654,20 @@ The `syncUserDoorAccess()` function is automatically called when:
 
 ### Workflow 10: Workshop Cancellation & Refund
 
-1. User cancels workshop registration from `/dashboard/myworkshops`
-2. System finds registration(s) with payment intent ID
-3. System checks cancellation policy (default: 48-hour refund window)
-4. Stripe refund processed for payment intent
-5. Registration record(s) deleted from database
-6. Cancellation confirmation email sent
-7. User refunded via Stripe
+Cancellation and refund are two separate steps. Cancelling never calls Stripe and never deletes anything — it flags the registration and queues it for an admin.
 
-**Note:** Multi-day workshop cancellations refund all occurrences in the series.
+**Step 1 — user cancels** (`cancelUserWorkshopRegistration()` / `cancelMultiDayWorkshopRegistration()`):
+1. User cancels from `/dashboard/myworkshops` or the workshop details page
+2. `UserWorkshop.result` is set to `"cancelled"` — the row is **not** deleted
+3. A `WorkshopCancelledRegistration` audit record is created, carrying the original `registrationDate`, the `cancellationDate`, the `paymentIntentId`, and `cancelledByAdmin: false`
+4. Cancellation confirmation email sent (`sendWorkshopCancellationEmail`)
+
+**Step 2 — admin refunds** (`refundWorkshopRegistration()`, separate action):
+1. Admin reviews the row in Admin Settings → Cancelled Events, where refund eligibility is displayed (cancelled at least 48 hours before the workshop start; for multi-day, before the earliest session)
+2. Stripe refund created against the stored payment intent
+3. **Only on a successful refund** are the `UserWorkshop` rows deleted
+
+**Note:** Multi-day cancellation marks every occurrence in the series cancelled but creates a single audit record, since the whole series shares one payment intent.
 
 ### Workflow 11: Equipment Booking (Single Slot)
 
@@ -685,22 +701,23 @@ The `syncUserDoorAccess()` function is automatically called when:
 
 ### Workflow 13: Equipment Cancellation & Refund
 
-1. User cancels equipment booking from `/dashboard/myequipments`
-2. System finds booking(s) with payment intent ID
-3. System checks refund eligibility:
-   - Cancellation 2+ days before slot start: Eligible
-   - Cancellation < 2 days before: Not eligible
-4. If eligible:
-   - Stripe refund processed
-   - Slot(s) marked as available (`isBooked: false`)
-   - Booking record(s) deleted
-   - Cancellation record created in `EquipmentCancelledBooking`
-5. Cancellation confirmation email sent
-6. User refunded via Stripe (if eligible)
+As with workshops, cancellation and refund are two separate steps. Cancelling never calls Stripe and never deletes the booking.
+
+**Step 1 — user cancels** (`cancelEquipmentBooking()`):
+1. User cancels from `/dashboard/myequipments`
+2. The slot is freed (`isBooked: false`) so someone else can take it
+3. An `EquipmentCancelledBooking` record is created via `createEquipmentCancellation()`, storing `totalSlotsBooked`, `slotsRefunded`, `totalPricePaid`, the proportional `priceToRefund`, the slot times as JSON, and `eligibleForRefund` — computed once at cancellation time as "the earliest cancelled slot starts more than 2 days from now"
+4. `EquipmentBooking.status` is set to `"cancelled"` — the row is **not** deleted
+5. Cancellation confirmation email sent (`sendEquipmentCancellationEmail`)
+
+**Step 2 — admin refunds** (`refundEquipmentBooking()`, separate action):
+1. Admin reviews the row in Admin Settings → Cancelled Events and sees the stored `eligibleForRefund` flag and `priceToRefund`
+2. Stripe refund created against the shared payment intent
+3. **Only on a successful refund** are the slots freed and the `EquipmentBooking` rows deleted
 
 **Partial Cancellation:**
-- User can cancel individual slots from bulk booking
-- Refund calculated proportionally (price per slot × cancelled slots)
+- User can cancel individual slots from a bulk booking
+- Refund calculated proportionally (original total price ÷ original slot count × slots cancelled), with the original totals carried forward from the first cancellation record so repeated partial cancellations stay consistent
 - Remaining slots remain booked
 
 ### Workflow 14: Automated Membership Billing (Cron Job)
@@ -883,7 +900,7 @@ Every implementation follows **implement → test → verify end to end**. The m
 1. Implement the feature
 2. Add test files under `tests/` and make them pass
 3. Verify end to end in a real browser via the Playwright MCP server
-4. `npm test` — the suite must stay fully green (**26 suites / 363 tests**)
+4. `npm test` — the suite must stay fully green (**27 suites / 372 tests**)
 5. `npm run typecheck`
 
 **Change to existing functionality** — assume this whenever an existing function, route, query, or schema field is edited, since the existing tests encode the old behaviour
@@ -971,6 +988,7 @@ The acceptance criteria are organized into three categories:
 | - | Equipment Basic Operations | Equipment CRUD operations, slot management, settings | `tests/models/equipment.basic.test.ts`, `tests/models/equipment.slots.test.ts`, `tests/models/equipment.settings.test.ts` |
 | - | Admin Workshop Creation | Admin creates new workshop; workshop form validation | `tests/routes/dashboard/addworkshop.test.ts` |
 | - | Admin Equipment Creation | Admin creates new equipment; equipment form validation | `tests/routes/dashboard/addequipment.test.ts` |
+| - | Workshop Registration Cutoff (server-side) | All four workshop URL shapes accepted by the `payment.tsx` loader — single occurrence, single + variation, multi-day, multi-day + variation — redirect away once `Workshop.registrationCutoff` has passed, and still load while registration is open; a cutoff of `0` means no restriction | `tests/routes/dashboard/payment.cutoff.test.ts` |
 
 ---
 
@@ -1080,8 +1098,8 @@ The following acceptance criteria should be manually tested by QA in the applica
 | ---- | **Workshop:** Delete Workshop Button | Go to /dashboard/workshops and click Delete Workshop (should show up) on a card | Workshops can only be deleted by admins and no one else | `NA` | `11/17/2025`
 | ---- | **Workshop Details:** Single Occurrence Workshop Dates | Go to workshop details | All dates created by workshop should show up and register individually | `NA` | `11/17/2025`
 | ---- | **Workshop Details:** Multi-day Workshop Dates | Go to workshop details | All dates created by workshop should show up and register together | `NA` | `11/17/2025`
-| ---- | **Workshop Details:** Single Occurrence Registration Cutoff | Go to workshop details | Dates that are within the cut off date before (from admin panel) it starts should not allow registration, even when typing in the URL | `NA` | `TODO/TOFIX`
-| ---- | **Workshop Details:** Multi-day Occurrence Registration Cutoff | Go to workshop details | The first date in the multi-day workshop and is within the cut off date (from admin panel) should not allow registration, even when typing in the URL | `NA` | `TODO/TOFIX`
+| ---- | **Workshop Details:** Single Occurrence Registration Cutoff | Go to workshop details, then try pasting `/dashboard/payment/:workshopId/:occurrenceId` and `/dashboard/payment/:workshopId/:occurrenceId/:variationId` for a date inside the cutoff window | Dates within the cutoff window do not allow registration, and typing either URL redirects to the role dashboard. Covered by `tests/routes/dashboard/payment.cutoff.test.ts` | `tests/routes/dashboard/payment.cutoff.test.ts` | `08/23/2026`
+| ---- | **Workshop Details:** Multi-day Occurrence Registration Cutoff | Go to workshop details, then try pasting `/dashboard/payment/:workshopId/connect/:connectId` and the `/:variationId` form | When the first date of the series is inside the cutoff window, registration is refused and both URLs redirect. Covered by `tests/routes/dashboard/payment.cutoff.test.ts`; not re-driven in a browser since the fix | `tests/routes/dashboard/payment.cutoff.test.ts` | `TODO/TOFIX`
 | ---- | **Workshop Details:** Single Occurrence Active Dates | Go to workshop details | All dates that are in the future and greater than the cut off date should be active (allowed for users to register) | `NA` | `11/17/2025`
 | ---- | **Workshop Details:** Multi-day Occurrence Active Dates | Go to workshop details | The first workshop date in the multi-day workshop that ius in the future and greater than the cut off date should be active (allowed for users to register) | `NA` | `11/17/2025`
 | ---- | **Workshop Details:** Single Occurrence Past Dates | Go to workshop details | All dates that are in the past and should not be registerable, even when putting in the URL | `NA` | `11/17/2025`
@@ -1194,8 +1212,8 @@ The following acceptance criteria should be manually tested by QA in the applica
 | AC46 | Membership Revocation (Admin) | Login as admin; navigate to user management; select user and click "Revoke Membership"; enter custom revocation message; confirm revocation | Revocation alert shown on user's memberships page; user receives revocation email with reason and timestamp; all user memberships show "revoked" status; revocation reason and date visible in admin user list |
 | AC47 | Revoked User Subscription Block | Login as revoked user; navigate to memberships page | Prominent alert displayed at top explaining membership access revoked; subscribe buttons on all membership cards disabled with tooltip; redirect to memberships page if attempting to access membership details or payment |
 | AC48 | Membership Unrevocation (Admin) | Login as admin; navigate to user management; select revoked user and click "Unrevoke Membership"; confirm unrevocation | Unrevocation alert shown; user receives unrevocation email; user can now subscribe to new memberships; no historical memberships are retroactively reactivated |
-| AC49 | **Brivo** Door Access Provisioning (Level 4 member) | Login as admin; ensure user has active membership with `needAdminPermission` plan; set user's `allowLevel4` flag to true; verify user role level is 4; check Brivo integration is configured; navigate to admin settings and verify user's Brivo sync status | User's `brivoPersonId` populated in database; user assigned to Brivo access groups (check Brivo dashboard); mobile pass invitation sent to user email; `brivoMobilePassId` stored in access card; door permission (ID: 0) added to access card permissions; `brivoLastSyncedAt` timestamp recorded; sync status shows "Provisioned" in admin settings | `N/A` | `11/29/2025` |
-| AC50 | **Brivo** Door Access Revocation (membership cancellation) | Have Level 4 user with active membership and Brivo access provisioned; cancel user's membership; check admin settings for user's Brivo sync status; verify in Brivo dashboard | User removed from Brivo access groups (check Brivo dashboard); mobile pass revoked in Brivo; door permission (ID: 0) removed from access card permissions; `brivoMobilePassId` cleared from access cards; `brivoLastSyncedAt` timestamp updated; sync status updated in admin settings | `N/A` | `11/29/2025` |
+| AC49 | **Brivo** Door Access Provisioning (Level 4 member) | Login as admin; ensure user has active membership with `needAdminPermission` plan; set user's `allowLevel4` flag to true; verify user role level is 4; check Brivo integration is configured; navigate to admin settings and verify user's Brivo sync status | User's `brivoPersonId` populated in database; user assigned to Brivo access groups (check Brivo dashboard); mobile pass invitation sent to user email; `brivoMobilePassId` stored in access card; `brivoLastSyncedAt` timestamp recorded (note: local ESP32 card `permissions` are **not** touched — the door-permission sync is deliberately disabled); sync status shows "Provisioned" in admin settings | `N/A` | `11/29/2025` |
+| AC50 | **Brivo** Door Access Revocation (membership cancellation) | Have Level 4 user with active membership and Brivo access provisioned; cancel user's membership; check admin settings for user's Brivo sync status; verify in Brivo dashboard | User removed from Brivo access groups (check Brivo dashboard); mobile pass revoked in Brivo; `brivoMobilePassId` cleared from access cards (local ESP32 card `permissions` are left untouched — they are admin-managed); `brivoLastSyncedAt` timestamp updated; sync status updated in admin settings | `N/A` | `11/29/2025` |
 | AC51 | **Brivo** Webhook Event Processing | Configure Brivo webhook subscription pointing to `/brivo/callback`; set `BRIVO_WEBHOOK_SECRET` environment variable; use Brivo credential (mobile pass or card) at door/equipment; check application logs; query `AccessLog` table | Webhook request received and signature verified; access event logged in `AccessLog` table with correct card ID, user ID, equipment name, and state (enter/exit/denied); response sent to Brivo with status "ok"; no errors in application logs | `N/A` | `N/A` |
 | AC52 | **Brivo** Admin Configuration | Login as admin; navigate to admin settings; scroll to "Brivo Access Control" section; verify integration status; select Brivo access group from dropdown; save settings; create/delete webhook subscription | Integration status shows "✓ Brivo API Connected" if credentials configured; access group dropdown populated with available Brivo groups; selected group ID saved to `brivo_access_group_level4` setting; webhook subscription created/deleted successfully; webhook URL shows `/brivo/callback` | `N/A` | `11/29/2025` |
 | AC53 | **Brivo** Sync Error Handling | Configure Brivo with invalid credentials or simulate API failure; attempt to provision user with Level 4 access; check admin settings for user's sync status; click "Retry Sync" button | Sync error message stored in `brivoSyncError` field; error badge displayed in admin user list; error details shown in sync status dialog; retry button triggers new sync attempt; if retry succeeds, error cleared and status updated | `N/A` | `11/29/2025` |
@@ -1272,6 +1290,7 @@ The following acceptance criteria should be manually tested by QA in the applica
   - ~~Orientation History confusing on if workshop is single occurrence or multi day **[ARIQ WILL DO THIS]**~~
   - ~~Disable in edit workshop the ability to uncheck and check "Add Workshop Price Variation"~~
   - ~~Workshop that are in the register cut-off phase can still be accessed and registered by typing URL: http://localhost:5173/dashboard/payment/:workshopID/:workshopOccurrenceID for single occurrence and http://localhost:5173/dashboard/payment/:workshopID/connect/:connectID for multi-day workshops~~
+    - The original fix covered only the two URL shapes named above. The price-variation form `/dashboard/payment/:workshopId/:occurrenceId/:variationId` was missed and stayed bypassable until it was fixed later. All four workshop branches of the `payment.tsx` loader now call `isPastRegistrationCutoff`, and `tests/routes/dashboard/payment.cutoff.test.ts` covers every shape so a future branch cannot silently skip it
   - ~~Need to notify users via email for users registered in a price variation if it has cancelled by the admin (need to handle for multi-day and regular workshops)~~
   - ~~People whos workshop registration in a price variation got cancelled should go into Workshop Cancelled Events to process refunds (need to handle for multi-day and regular workshops)~~
   - ~~When having a workshop that books equipments during its workshop occurrence times slots, editing the workshop and removing that equipment and pressing Update Workshop button, it does not remove the equipment from the workshop at all and in turn, does not free up the time slot (this for some reason only if you have a workshop for example with equipment Lazer Cutter and then you want to remove Lazer Cutter; the equipment will not be removed and so the slots do not free up. But if you have like Lazer Cutter and CNC Milling equipment and you remove CNC Milling, it will remove properly. Maybe it only does that if you are going from a workshop that books equipment to one that doesn't anymore after editing)~~

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ npx playwright install chromium   # one-time, only if the browser binary is miss
 
 Then browse `http://localhost:5173`. This is for **interactive verification** — clicking through a flow, checking what a page renders, reading console errors. Automated regression tests belong in `tests/` under Jest; see [Testing Strategy](#testing-strategy).
 
+The server writes page snapshots and console logs into `.playwright-mcp/` at the repo root as you drive it. That directory is gitignored — it is session scratch, not something to commit.
+
 ## Environment Variables & Configuration
 
 ### Required Environment Variables
@@ -420,7 +422,7 @@ All server-side code uses the `*.server.ts` naming convention. These files:
 - **Special Flag:** `allowLevel4` — Boolean flag that must be explicitly granted by admin for Level 4 access
 - **Access Requirements:** Most equipment requires Level 3+, some require Level 4 with the flag
 - Role checks are enforced in loaders/actions and at the model layer
-- **Role Level Sync Cron:** `startRoleLevelSyncCron()` in `app/models/user.server.ts` — runs every 15 seconds (`*/15 * * * * *`), corrects any drift across all users in a single batched DB query
+- **Role Level Sync Cron:** `startRoleLevelSyncCron()` in `app/models/user.server.ts` — runs every 15 seconds (`*/15 * * * * *`). It loads every user in one batched read (with their passed orientations and non-inactive memberships), then writes per user, updating and re-syncing door access only for those whose level actually drifted
 
 ### Cron Jobs
 
@@ -451,7 +453,7 @@ The workshop status job runs immediately on startup and then every 1 second, kee
 **Multi-day Workshops:** Connected via shared `connectId` on `WorkshopOccurrence`. All occurrences must be registered together as a single unit.
 
 **Registration Rules:**
-- **Cutoff Time**: `Workshop.registrationCutoff`, in minutes before start (schema default 60). Set per-workshop from Admin Settings via `updateWorkshopCutoff()`; enforced in the UI in `workshopdetails.tsx` and server-side in `payment.tsx`
+- **Cutoff Time**: `Workshop.registrationCutoff`, in minutes before start (schema default 60); `0` or null means no cutoff. Set per-workshop from Admin Settings via `updateWorkshopCutoff()`. Enforced in the UI in `workshopdetails.tsx`, and server-side by the module-local `isPastRegistrationCutoff` helper (internal to `payment.tsx`, not exported) in **all four** workshop branches of the `payment.tsx` loader — single occurrence, single + variation, multi-day, and multi-day + variation. The loader is the only server-side gate: neither `quickCheckout()` nor `paymentsuccess.tsx` re-checks the cutoff, so a branch that skips it is bypassable by URL. `tests/routes/dashboard/payment.cutoff.test.ts` covers every shape
 - **Capacity**: Tracked per occurrence or across multi-day series
 - **Price Variations**: `WorkshopPriceVariation` records with individual capacity limits
 - **Cancellation Policy**: Refund eligible if cancelled at least 48 hours before the workshop start time (eligibility checked in Cancelled Events tab in Admin Settings). The policy text is hardcoded in `app/routes/dashboard/workshopdetails.tsx` — the `Workshop.cancellationPolicy` DB field exists but is no longer rendered in the UI
@@ -517,7 +519,7 @@ Each workshop, membership plan, and equipment item is automatically linked to a 
   - `syncEquipmentToStripe(id)` — creates or updates Stripe Product for equipment
   - `archiveStripeProduct(stripeProductId)` — marks Stripe Product inactive (used on delete; items are archived, not deleted)
   - `bulkSyncToStripe(clearExisting = false)` — syncs all three categories in one pass; `clearExisting: true` backs the Clear & Re-sync action
-- **Auto-Sync Hooks:** Called non-blocking (`.catch()`) from model create/update/delete functions in workshop, membership, and equipment models
+- **Auto-Sync Hooks:** Create, update, and duplicate call the sync non-blocking (`.catch()`) in the workshop, membership, and equipment models. Delete instead `await`s `archiveStripeProduct()` before removing the row — that call swallows its own errors, so a Stripe outage still cannot block the delete
 - **Checkout:** `payment.server.ts` and `payment.tsx` use `price_data.product` when `stripeProductId` exists, falling back to inline `price_data.product_data` if not set
 - **Admin API:** `POST /api/stripe-sync` with actions: `bulkSync`, `clearAndResync`, `getSyncStatus`
 - **Admin UI:** Admin Settings → "Stripe Products" tab — Sync All, Clear & Re-sync buttons with status display
@@ -1039,7 +1041,7 @@ Assume you are here whenever you edit an existing function, route, query, or sch
 
 **Most changes are the second kind.** When unsure, treat it as the second kind.
 
-The suite is currently **fully green — 26 suites, 363 tests** — and every server module is covered. That baseline is what makes step 4 meaningful: a failure after your change is a regression you introduced, not background noise. Do not commit on a red suite without saying so explicitly.
+The suite is currently **fully green — 27 suites, 372 tests** — and every server module is covered. That baseline is what makes step 4 meaningful: a failure after your change is a regression you introduced, not background noise. Do not commit on a red suite without saying so explicitly.
 
 **Rules:**
 
@@ -1066,14 +1068,20 @@ The suite is currently **fully green — 26 suites, 363 tests** — and every se
 **[tests/README.md](./tests/README.md) is the full reference** for the folder — layout, fixture conventions, the import-ordering rule, and the failure modes that have actually bitten here. Read it before adding or changing a test
 
 **Model tests** (`tests/models/`):
-`equipment.basic`, `equipment.booking`, `equipment.cancellation`, `equipment.settings`, `equipment.slots`, `membership.cron`, `membership.server`, `workshop.basic`, `workshop.cancellation`, `workshop.capacity`, `workshop.registration`
+`access.card-log`, `admin.settings`, `equipment.basic`, `equipment.booking`, `equipment.cancellation`, `equipment.settings`, `equipment.slots`, `issue.server`, `membership.cron`, `membership.server`, `payment.gst`, `payment.refunds`, `profile.volunteer`, `user.rolelevel`, `workshop.basic`, `workshop.cancellation`, `workshop.capacity`, `workshop.move`, `workshop.registration`
+
+**Service tests** (`tests/services/`):
+`access-control-sync.server`, `brivo.server`, `stripe-sync.server`
+
+**Util and config tests:**
+`tests/utils/session.server.test.ts`, `tests/config/access-control.test.ts`
 
 **Route tests** (`tests/routes/dashboard/`):
-`addequipment.test.ts`, `addworkshop.test.ts`
+`addequipment.test.ts`, `addworkshop.test.ts`, `payment.cutoff.test.ts`
 
 **Support:**
 - `tests/helpers/db.mock.ts`, `tests/helpers/test-utils.ts`
-- Fixtures in `tests/fixtures/` — `equipment/`, `membership/`, `session/`, `workshop/`
+- Fixtures in `tests/fixtures/` — `equipment/`, `membership/`, `payment/`, `session/`, `user/`, `workshop/`
 
 **Seed data:**
 - `seed.ts` provides consistent test data; **requires `NODE_ENV=development`** — it logs `Seed aborted` and exits immediately otherwise. Occurrence dates are relative to `now` (e.g. `addDays(now, 7)`) so workshops always appear upcoming regardless of when the seed runs. It truncates and reseeds `RoleUser`, restarting the sequence so `User` = 1 and `Admin` = 2

--- a/app/routes/dashboard/payment.tsx
+++ b/app/routes/dashboard/payment.tsx
@@ -319,6 +319,15 @@ export const loader: LoaderFunction = async ({ params, request }) => {
       throw redirect(getRedirectPath());
     }
 
+    if (
+      isPastRegistrationCutoff(
+        new Date(occurrence.startDate),
+        workshop.registrationCutoff
+      )
+    ) {
+      throw redirect(getRedirectPath());
+    }
+
     const gstPercentage = await getAdminSetting("gst_percentage", "5");
 
     return {

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,7 @@
 
 Jest test suite for the MSYK Membership Management System.
 
-**Current state: 26 suites, 363 tests, all passing.** Every server module under `app/models/`, `app/services/`, `app/utils/session.server.ts`, and `app/config/` has coverage. That green baseline is what makes a failure meaningful — if the suite goes red after your change, you caused it.
+**Current state: 27 suites, 372 tests, all passing.** Every server module under `app/models/`, `app/services/`, `app/utils/session.server.ts`, and `app/config/` has coverage. That green baseline is what makes a failure meaningful — if the suite goes red after your change, you caused it.
 
 ```bash
 npm test                                      # everything
@@ -54,7 +54,8 @@ tests/
 │   └── session.server.test.ts
 ├── routes/dashboard/            # route loaders and actions
 │   ├── addequipment.test.ts
-│   └── addworkshop.test.ts
+│   ├── addworkshop.test.ts
+│   └── payment.cutoff.test.ts
 ├── fixtures/                    # per-domain mock setup + sample data
 │   ├── equipment/   {setup,equipments,addEquimentForm,getEquipmentSlotsWithStatus}.ts
 │   ├── membership/  {setup,memberships}.ts

--- a/tests/routes/dashboard/payment.cutoff.test.ts
+++ b/tests/routes/dashboard/payment.cutoff.test.ts
@@ -1,0 +1,208 @@
+// session.server throws at import time if SESSION_SECRET is unset, and payment.tsx
+// pulls it in transitively — so this side-effect import must stay on the first line.
+import "tests/fixtures/session/setup";
+
+import { getUser, getRoleUser } from "~/utils/session.server";
+import { getSavedPaymentMethod, getUserById } from "~/models/user.server";
+import {
+  getWorkshopById,
+  getWorkshopOccurrence,
+  getWorkshopOccurrencesByConnectId,
+  getWorkshopPriceVariation,
+  checkWorkshopCapacity,
+  checkMultiDayWorkshopCapacity,
+} from "~/models/workshop.server";
+import { getAdminSetting } from "~/models/admin.server";
+import { loader } from "~/routes/dashboard/payment";
+
+// payment.tsx constructs a Stripe client at module load from STRIPE_SECRET_KEY,
+// which is absent under Jest, so the real module would throw on import.
+jest.mock("stripe", () => {
+  const stripeConstructorMock = jest.fn().mockImplementation(() => ({
+    checkout: { sessions: { create: jest.fn() } },
+  }));
+  return {
+    __esModule: true,
+    Stripe: stripeConstructorMock,
+    default: stripeConstructorMock,
+  };
+});
+
+jest.mock("~/utils/session.server");
+jest.mock("~/models/user.server");
+jest.mock("~/models/workshop.server");
+jest.mock("~/models/membership.server");
+jest.mock("~/models/admin.server");
+jest.mock("~/logging/logger");
+
+const mockGetUser = getUser as jest.Mock;
+const mockGetRoleUser = getRoleUser as jest.Mock;
+const mockGetUserById = getUserById as jest.Mock;
+const mockGetSavedPaymentMethod = getSavedPaymentMethod as jest.Mock;
+const mockGetWorkshopById = getWorkshopById as jest.Mock;
+const mockGetWorkshopOccurrence = getWorkshopOccurrence as jest.Mock;
+const mockGetWorkshopOccurrencesByConnectId =
+  getWorkshopOccurrencesByConnectId as jest.Mock;
+const mockGetWorkshopPriceVariation = getWorkshopPriceVariation as jest.Mock;
+const mockCheckWorkshopCapacity = checkWorkshopCapacity as jest.Mock;
+const mockCheckMultiDayWorkshopCapacity =
+  checkMultiDayWorkshopCapacity as jest.Mock;
+const mockGetAdminSetting = getAdminSetting as jest.Mock;
+
+const MINUTE = 60 * 1000;
+const REGISTRATION_CUTOFF_MINUTES = 60;
+
+/**
+ * The four workshop URL shapes the payment loader accepts. Each must enforce
+ * Workshop.registrationCutoff — the loader is the only server-side gate, since
+ * neither quickCheckout() nor paymentsuccess.tsx re-checks it.
+ */
+const URL_SHAPES: Array<{
+  name: string;
+  params: Record<string, string>;
+  isMultiDay: boolean;
+}> = [
+  {
+    name: "single occurrence, no price variation",
+    params: { workshopId: "1", occurrenceId: "10" },
+    isMultiDay: false,
+  },
+  {
+    name: "single occurrence, with price variation",
+    params: { workshopId: "1", occurrenceId: "10", variationId: "5" },
+    isMultiDay: false,
+  },
+  {
+    name: "multi-day, no price variation",
+    params: { workshopId: "1", connectId: "3" },
+    isMultiDay: true,
+  },
+  {
+    name: "multi-day, with price variation",
+    params: { workshopId: "1", connectId: "3", variationId: "5" },
+    isMultiDay: true,
+  },
+];
+
+/**
+ * Builds an occurrence that starts `startsInMinutes` from now and always ends in
+ * the future, so the loader's "occurrence already ended" guard never fires and
+ * mask the cutoff result we are actually asserting on.
+ */
+function buildOccurrence(startsInMinutes: number) {
+  const now = Date.now();
+  return {
+    id: 10,
+    workshopId: 1,
+    startDate: new Date(now + startsInMinutes * MINUTE),
+    endDate: new Date(now + (startsInMinutes + 180) * MINUTE),
+    status: "active",
+    connectId: null,
+  };
+}
+
+function primeMocks(startsInMinutes: number, isMultiDay: boolean) {
+  const occurrence = buildOccurrence(startsInMinutes);
+
+  mockGetUser.mockResolvedValue({ id: 1, email: "user@example.com", roleLevel: 3 });
+  mockGetRoleUser.mockResolvedValue({ userId: 1, roleId: 1, roleName: "User" });
+  mockGetUserById.mockResolvedValue({
+    id: 1,
+    roleLevel: 3,
+    allowLevel4: false,
+    membershipStatus: "active",
+  });
+  mockGetSavedPaymentMethod.mockResolvedValue(null);
+
+  mockGetWorkshopById.mockResolvedValue({
+    id: 1,
+    name: "Laser Cutting Basics",
+    price: 30,
+    location: "Makerspace YK",
+    capacity: 15,
+    type: "workshop",
+    registrationCutoff: REGISTRATION_CUTOFF_MINUTES,
+    stripeProductId: null,
+  });
+  mockGetWorkshopOccurrence.mockResolvedValue(occurrence);
+  mockGetWorkshopOccurrencesByConnectId.mockResolvedValue([occurrence]);
+  mockGetWorkshopPriceVariation.mockResolvedValue({
+    id: 5,
+    workshopId: 1,
+    name: "Student",
+    price: 20,
+    description: "Student pricing",
+    capacity: 5,
+    status: "active",
+  });
+  mockCheckWorkshopCapacity.mockResolvedValue({ hasCapacity: true });
+  mockCheckMultiDayWorkshopCapacity.mockResolvedValue({ hasCapacity: true });
+  mockGetAdminSetting.mockResolvedValue("5");
+
+  return occurrence;
+}
+
+async function runLoader(params: Record<string, string>) {
+  const request = new Request("http://localhost:5173/dashboard/payment");
+  return loader({ request, params, context: {} } as any);
+}
+
+describe("payment loader — registration cutoff", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe.each(URL_SHAPES)("$name", ({ params, isMultiDay }) => {
+    it("redirects away when the registration cutoff has passed", async () => {
+      // Starts in 30 minutes with a 60-minute cutoff, so registration closed 30
+      // minutes ago. The occurrence has not started, so only the cutoff can reject it.
+      primeMocks(30, isMultiDay);
+
+      let thrown: unknown;
+      try {
+        await runLoader(params);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Response);
+      const response = thrown as Response;
+      expect(response.status).toBe(302);
+      expect(response.headers.get("Location")).toBe("/dashboard/user");
+    });
+
+    it("loads the payment page when the cutoff has not passed", async () => {
+      // Starts in 3 hours with a 60-minute cutoff, so registration is still open.
+      primeMocks(180, isMultiDay);
+
+      const result = await runLoader(params);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          isMultiDayWorkshop: isMultiDay,
+          gstPercentage: 5,
+        })
+      );
+    });
+  });
+
+  it("treats a zero or missing cutoff as no restriction", async () => {
+    primeMocks(1, false);
+    mockGetWorkshopById.mockResolvedValue({
+      id: 1,
+      name: "Laser Cutting Basics",
+      price: 30,
+      location: "Makerspace YK",
+      capacity: 15,
+      type: "workshop",
+      registrationCutoff: 0,
+      stripeProductId: null,
+    });
+
+    const result = await runLoader({ workshopId: "1", occurrenceId: "10" });
+
+    expect(result).toEqual(
+      expect.objectContaining({ isMultiDayWorkshop: false })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two things, both surfaced by a `/read-docs` pass over the codebase.

The first is a real bypass: a workshop with price variations could be paid for and registered **after its registration cutoff had passed**, by pasting the payment URL. The UI correctly refused, and three of the four workshop branches of the `payment.tsx` loader correctly refused — but the single-occurrence-with-variation branch never checked, and nothing downstream re-checks.

The second is documentation drift. Auditing the maintained docs against the source turned up nine places where they described behaviour the code does not have — including two workflows that were the inverse of what actually happens. Those are corrected here, and `/read-docs` itself is rewritten so this kind of audit stops costing an entire context window.

## The bug

`Workshop.registrationCutoff` (schema default `60`) is the number of minutes before start when registration closes. The `payment.tsx` loader is the **only** server-side gate on it — neither `quickCheckout()` in `payment.server.ts` nor `paymentsuccess.tsx` re-validates it, so once the loader lets a request through, the registration lands.

The loader branches four ways, and one branch was missing the check:

| URL shape | cutoff enforced before | after |
|---|---|---|
| `/dashboard/payment/:workshopId/:occurrenceId` | yes | yes |
| `/dashboard/payment/:workshopId/:occurrenceId/:variationId` | **no** | yes |
| `/dashboard/payment/:workshopId/connect/:connectId` | yes | yes |
| `/dashboard/payment/:workshopId/connect/:connectId/:variationId` | yes | yes |

Concretely: a workshop with price variations starting at 2:00pm with a 60-minute cutoff would refuse registration in the UI at 1:30pm, but `/dashboard/payment/12/45/3` loaded the payment page and completed the purchase. It also worked for a workshop that had already *started*, up until its `endDate`.

### How it happened

The bug list in `MSYK-OVERVIEW.md` records the original report, and it names exactly two URL shapes — `/:workshopID/:workshopOccurrenceID` and `/:workshopID/connect/:connectID`. Both are the no-variation forms. The fix was applied to those two, also caught multi-day + variation, and missed single + variation. That struck-through entry now carries a note saying so, since the same omission is easy to repeat.

### What was still guarding it

Worth being precise about severity: the branch still rejected cancelled occurrences, occurrences past their `endDate`, and full workshops (including per-variation capacity via `checkWorkshopCapacity`). The user still paid the correct amount and still consumed a real seat. This was a business-rule bypass, not a data-integrity or payment problem.

## Edge cases handled

- **Cutoff of `0` or `null`** — `isPastRegistrationCutoff` returns `false` early, so "no cutoff configured" continues to mean no restriction rather than blocking everything. Covered by an explicit test case
- **Occurrence already started but not ended** — now rejected. Previously the `endDate < now` guard let this through, because a workshop that started 20 minutes ago has not ended
- **Multi-day series** — the check runs against `occurrences[0].startDate`, matching the existing multi-day branches and the admin-facing rule that a series closes on its first date
- **Redirect target** — reuses the branch's existing `getRedirectPath()`, so admins land on `/dashboard/admin` and members on `/dashboard/user`, consistent with every other guard in the loader
- **Quick checkout** — deliberately unchanged. It is only reachable from the payment page, which the loader now gates on all four shapes. `CLAUDE.md` records that the loader is the sole gate, so a future fifth branch does not silently reopen this
- **Regression shape** — `tests/routes/dashboard/payment.cutoff.test.ts` is parametrised over all four URL shapes rather than testing only the one that broke. Verified it fails against the unfixed code, and fails on exactly one branch

Verified in the browser via the Playwright MCP server: logged in as a member, put occurrence 12 of a price-variation workshop 30 minutes out against its 60-minute cutoff, and confirmed `/dashboard/payment/9/12/1` redirects to `/dashboard/user`; then moved the occurrence outside the window and confirmed the payment page renders the correct variation and GST-inclusive total.

## Documentation corrections

The audit compared every factual claim in `README.md`, `CLAUDE.md`, and `MSYK-OVERVIEW.md` against the source. Nine corrections:

- **Admin Settings tabs** — `MSYK-OVERVIEW.md` listed four tabs ("General", "Google Calendar", "Brivo", "Stripe Products"). The actual `TabsTrigger` values are eleven, and none of the first three exist: GST lives under **Miscellaneous Settings**, and Google Calendar and Brivo are both cards inside **Integrations**
- **Workshop cancellation (Workflow 10)** — claimed cancelling processes a Stripe refund and deletes the registration. `cancelUserWorkshopRegistration()` sets `result: "cancelled"` and writes a `WorkshopCancelledRegistration` audit row; it never calls Stripe. Deletion happens only inside `refundWorkshopRegistration()`, a separate admin action, and only on a successful refund. Rewritten as two explicit steps
- **Equipment cancellation (Workflow 13)** — same inversion, same fix. `cancelEquipmentBooking()` frees the slot and sets `status: "cancelled"`; `refundEquipmentBooking()` is what refunds and deletes
- **Role level and cancelled memberships** — the doc said a cancelled membership drops a user to Level 2. `startRoleLevelSyncCron()` counts `active`, `ending`, and `cancelled` as a membership on file, so a cancelled member stays at Level 3 until the billing cron flips the record to `inactive`. Brivo is stricter and gates on `status === "active"` alone, so the same user loses the physical door immediately — that asymmetry is now written down
- **AC49 / AC50** — both expected door permission ID `0` to be written to and removed from `AccessCard.permissions`. That sync (`mergeDoorPermission` / `syncAccessCards`) is commented out in `access-control-sync.server.ts`; local ESP32 fob permissions are admin-managed and never auto-modified. The document already said this correctly elsewhere and contradicted itself
- **Role level sync cron** — described as correcting drift "in a single batched DB query". It is a single batched *read*, followed by per-user writes for only the users whose level actually drifted
- **Registration cutoff** — now states it is enforced in all four loader branches, that `isPastRegistrationCutoff` is module-local rather than exported, and that the loader is the only server-side gate
- **Stripe sync hooks** — described as non-blocking for create/update/delete. Create, update, and duplicate use `.catch()`; delete `await`s `archiveStripeProduct()`, which swallows its own errors
- **Test inventory** — `README.md` listed 11 of the 19 model specs and 4 of the 6 fixture domains. Both lists are now complete, and the suite count is updated to **27 suites / 372 tests** everywhere it is cited

## `/read-docs` rewrite

The audit above was only possible because `/read-docs` read every markdown and roughly 52,000 lines of source into one context. It produced an accurate model and left almost nothing to work with. The command is rewritten around a different rule — *read cheap structured things yourself, delegate expensive unstructured reading to subagents, read a specific file in full only when the task touches it* — with an explicit budget of under 10% of the context window.

- **Phase 0** skips `CLAUDE.md` (already auto-loaded), reads `tests/README.md` and `.claude/README.md`, and indexes `README.md` / `MSYK-OVERVIEW.md` by heading instead of reading them cover to cover
- **Phase 1** builds a structural map with `grep`/`sed`: data model, full route table, every exported model and service function, cron schedules, env vars, `AdminSettings` keys
- **Phase 2** fans out up to three `Explore` subagents (business logic, request layer, auth/config), each capped at a 40-line brief. The bulk of the source is read in *their* context; only the briefs reach the main one
- **Phase 3** keeps the four cheap mechanical checks — route files registered, routes in the README map, documented functions actually exported, referenced paths exist — and drops the claim-by-claim prose audit. `/update-all-docs` covers drift as code changes; a full audit is now something you ask for explicitly
- **Phase 4** reports in under 40 lines and ends with an explicit list of what it did *not* read

`.playwright-mcp/` is also gitignored — the MCP server drops page snapshots and console logs there, and they were landing untracked in the repo root.

## Note on the branch

`feat/fall-2026-platform-updates` already had a PR merged earlier today (#417). This PR is the eight commits added on top of it; the diff is against the current `main` and does not re-include that work.
