### PR TITLE
feat: seed role level 2-4 accounts and test background jobs

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -39,7 +39,9 @@ Reach for it when:
 Notes for using it here:
 - Start the app first (`npm run dev`) and browse to `http://localhost:5173`. The MCP server does not start the app for you
 - `npm run dev` runs both the client and the cron server; the cron server is what flips workshop occurrence status, so start both when timing matters
-- You need a seeded database to log in — `npx tsx seed.ts` (requires `NODE_ENV=development`)
+- You need a seeded database to log in — `npx tsx seed.ts` (requires `NODE_ENV=development`). It creates `testuser1@gmail.com` (**admin**) through `testuser6@gmail.com`, all with the password `password`: 1–3 are role level 1, then `testuser4` is level 2, `testuser5` level 3, and `testuser6` level 4. Those levels come from real seeded rows (passed orientation, active membership, `allowLevel4`), so the sync cron leaves them alone — but for the same reason, hand-editing `roleLevel` is reverted within 15s
+- **Check mobile.** Resize the browser to a phone-width viewport and look at the page. Mobile responsiveness is required of every UI change here, and it is the thing most often missed
+- **Ask if you are blocked.** If driving the flow needs something you do not have — a test card, a sandbox credential, a record in a particular state, a decision about what should happen — ask for it rather than skipping the verification
 - Chromium is already installed locally. If it is ever missing, `npx playwright install chromium`
 - The server drops page snapshots and console logs into `.playwright-mcp/` as you drive it. That directory is gitignored — do not commit it
 - This is for **interactive verification**, not an automated test suite. Regression tests belong in `tests/` under Jest
@@ -63,7 +65,7 @@ What it does:
 - **Phase 1 — structural map.** A handful of `grep`/`sed` commands that yield the data model, the full route table, every exported model/service function, cron schedules, env vars, and `AdminSettings` keys — the shape of the system for a fraction of the tokens the source costs
 - **Phase 2 — delegated deep reading.** Up to three `Explore` subagents in parallel (business logic, request layer, auth/config), each capped at a 40-line brief. The ~50,000 lines are read in *their* context; only the briefs reach the main one. Fewer subagents when the task is narrow
 - **Phase 3 — mechanical verification.** Four cheap shell checks: every route file registered, every route in the README map, documented functions actually exported, referenced paths exist. It does **not** audit the prose claim by claim — `/update-all-docs` keeps docs honest as code changes, and a full audit is something you ask for explicitly
-- **Phase 4 — a report under ~40 lines**, ending with an explicit list of what it did *not* read
+- **Phase 4 — a report under ~40 lines**, ending with an explicit list of what it did *not* read, then the standing invitation to ask clarifying questions before implementation begins
 
 Deliberate omissions, in the command itself: the frozen write-ups in `docs/implementations/` (reading them builds a false picture of current behavior), the ~12,700-line Brivo API snapshot (read on demand), and the JSX of the six largest route files (their loaders and actions are read; their markup is not).
 
@@ -119,12 +121,13 @@ Creates a pull request into `main` for the current branch. Key rules it enforces
 ## Typical flow
 
 1. `/read-docs` at the start of a session to build a verified mental model
-2. **Implement** the change
-3. **Test it** — *add* test files for new functionality, or *update* the existing tests a change to existing functionality invalidated. Most changes are the latter
-4. **Verify end to end** in a browser via the Playwright MCP server — a green unit test says the function behaves, only the browser says the feature works
-5. **Run the full suite** (`npm test`) — it is currently fully green, so any failure is yours
-6. `/update-all-docs` to bring the documentation back in line with the code
-7. `/commit` to split the work into logical commits
-8. `/make-pr` to open the pull request
+2. **Ask first** — put your clarifying questions to the maintainer before implementing anything non-trivial: *"ask me any clarifying questions and anything you need from me to do this, we are a team."* Scope, edge cases, a choice between two designs, credentials you lack — all cheaper to settle now
+3. **Implement** the change — mobile responsive, with short comments that earn their line (see `CLAUDE.md`)
+4. **Test it** — *add* test files for new functionality, or *update* the existing tests a change to existing functionality invalidated. Most changes are the latter
+5. **Verify end to end** in a browser via the Playwright MCP server, at desktop *and* mobile width — a green unit test says the function behaves, only the browser says the feature works
+6. **Run the full suite** (`npm test`) — it is currently fully green, so any failure is yours
+7. `/update-all-docs` to bring the documentation back in line with the code
+8. `/commit` to split the work into logical commits
+9. `/make-pr` to open the pull request
 
-Steps 2–5 are mandatory for every implementation. The full rules are in `CLAUDE.md`; `tests/README.md` covers the test folder itself.
+Steps 3–6 are mandatory for every implementation, and step 2 is what keeps them from being wasted. If any of them needs something only the maintainer can supply — a credential, a seeded record, a level 3/4 account, a ruling on expected behaviour — ask for it instead of working around it. The full rules are in `CLAUDE.md`; `tests/README.md` covers the test folder itself.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -17,7 +17,7 @@ Read the diff. Do not commit changes you have not read.
 
 **Run `npm test` and `npm run typecheck` before the first commit.**
 
-- `npm test` — the suite is fully green (27 suites / 372 tests). A failure after your change is a regression you introduced; fix it before committing rather than committing over it
+- `npm test` — the suite is fully green (29 suites / 388 tests). A failure after your change is a regression you introduced; fix it before committing rather than committing over it
 - `npm run typecheck` — regenerates React Router types and type-checks the project. Three pre-existing errors in `old/webhooks.server.ts` are known and unrelated
 
 If either fails for a reason genuinely unrelated to your change, say so explicitly and continue.

--- a/.claude/commands/read-docs.md
+++ b/.claude/commands/read-docs.md
@@ -123,3 +123,9 @@ Keep the whole report under ~40 lines. You are confirming readiness, not demonst
 **Not read** — name what you skipped: the two carve-outs above, the JSX of the large route files, and any subsystem whose subagent you chose not to run. Being explicit here is what makes the rest of the report trustworthy.
 
 Then stop and start the actual work. Read the specific files that work touches, when you touch them.
+
+Before implementing, close the report with the invitation the workflow expects:
+
+> Ask me any clarifying questions and anything you need from me to do this. We are a team.
+
+…and ask yours — scope, edge cases, a choice between designs, credentials or accounts you need to test with. `CLAUDE.md` has the rest of the standing rules: mobile responsive UI, short comments that earn their line, and asking rather than skipping when a test or browser verification needs something you do not have.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,18 @@ Supporting material in `docs/` — the root is reserved for the three primary do
 - **[docs/apidocs.brivo.com_.2025-11-25T01_49_47.688Z.md](./docs/apidocs.brivo.com_.2025-11-25T01_49_47.688Z.md)** - Vendor Brivo API reference snapshot. Authoritative for the endpoints `app/services/brivo.server.ts` calls — read before changing the door access integration. Never edit
 - **[docs/implementations/](./docs/implementations/)** - Point-in-time write-ups of individual implementations, written once when the work landed and deliberately not maintained afterwards. Historical records, not current behavior
 
+### Before you start any implementation
+
+**Ask clarifying questions first. We are a team — say so, and mean it.**
+
+Before writing code for anything non-trivial, tell the user:
+
+> Ask me any clarifying questions and anything you need from me to do this. We are a team.
+
+…and then actually ask yours. Surface anything that would change what you build: ambiguous scope, two reasonable designs, a missing decision, an unclear edge case, access or credentials you do not have. A question asked up front costs a minute; a wrong assumption costs the whole implementation. Do the parts that do not depend on the answer while you wait.
+
+Never guess silently at something the user can answer in one sentence.
+
 ### Required workflow for every implementation
 
 **Implement → test → verify end to end. All three steps, every time. Never stop after the code compiles.**
@@ -57,7 +69,7 @@ First decide which of the two cases you are in, because it changes step 2:
 1. **Implement** the feature
 2. **Add test files for it** under `tests/`, following the existing layout, and run them until they pass
 3. **Verify end to end with Playwright MCP** — drive the real flow in the browser and confirm it behaves as expected
-4. **Regress** — `npm test` must stay fully green (currently **27 suites / 372 tests**)
+4. **Regress** — `npm test` must stay fully green (currently **29 suites / 388 tests**)
 5. **Typecheck** — `npm run typecheck` (three pre-existing errors in `old/webhooks.server.ts` are known and unrelated)
 
 #### Case B — the change touches existing functionality
@@ -78,10 +90,36 @@ Rules:
 - **A suite reporting `0 total` is broken, not passing.** Five equipment suites silently ran zero tests for months while looking green
 - **A bug fix should carry a test that would have caught it**
 - Match the existing layout — see [tests/README.md](./tests/README.md)
+- **Ask for help when testing needs it.** If you cannot write the test or drive the browser flow without something only the user can give you — a seeded record, a Stripe test card, a Brivo sandbox key, a role level 3/4 account, an admin toggle flipped, a decision about expected behaviour — **ask**. Do not skip the step, fake it, or quietly assert something weaker. Being blocked is fine; going silent about it is not
+
+### Code conventions for every change
+
+**Mobile responsive is a requirement, not a nice-to-have.** Every UI change must work on a phone-width viewport, not just desktop. Use the Tailwind responsive prefixes the codebase already uses (`sm:`, `md:`, `lg:`), let tables and wide grids scroll inside their own container rather than pushing the page sideways, and keep tap targets reachable. Verify it — resize the browser to a mobile viewport in the Playwright MCP session, do not just assume the classes work.
+
+**Keep code comments short.** Comment where it helps, but a comment must earn its line: clear, concise, relevant, and telling the reader something the code does not already say. Prefer one sentence explaining *why* over a paragraph restating *what*.
+
+- Do not stack a run of single-line comments over consecutive statements — that is noise, and it ages badly
+- Do not narrate obvious code (`// loop through users`)
+- Do not leave running commentary about your own edits (`// changed this to fix the bug`)
+- Do explain a non-obvious constraint, a workaround, or a rule that lives outside the file
+- Match the comment density of the surrounding file
 
 ### Browser Testing (Playwright MCP)
 
 `.mcp.json` registers the `@playwright/mcp` server, giving you a real Chromium browser. **Use it to verify UI and flow changes in the running app instead of assuming they work.** Start the app with `npm run dev` first (nothing auto-starts it), seed the DB if you need to log in, then drive `http://localhost:5173`. Chromium is already installed. See [.claude/README.md](./.claude/README.md) for guidance on when to reach for it.
+
+**Test accounts** — seeded by `npx tsx seed.ts` (requires `NODE_ENV=development`). All six share the password `password`, and cover every role level:
+
+| Email | Password | Role level | How the level is earned |
+|-------|----------|-----------|--------------------------|
+| `testuser1@gmail.com` | `password` | 1 — **Admin** (`roleUserId: 2`) | Admin role; no orientation or membership |
+| `testuser2@gmail.com` | `password` | 1 | Registered only |
+| `testuser3@gmail.com` | `password` | 1 | Registered only |
+| `testuser4@gmail.com` | `password` | 2 | Passed a past General Orientation |
+| `testuser5@gmail.com` | `password` | 3 | Orientation + active **Makerspace Member** membership |
+| `testuser6@gmail.com` | `password` | 4 | Orientation + active **Drop-In 10 Pass** (`needAdminPermission`) + `allowLevel4` |
+
+None of these levels are written directly. The seed creates the rows that *earn* them — a `UserWorkshop` with `result: "passed"` on an orientation, a `UserMembership` with status `active`, the `allowLevel4` flag — and then derives `roleLevel` from those rows using the same rules as `startRoleLevelSyncCron()`. That cron re-derives the level every 15 seconds, so **editing `roleLevel` by hand does not stick**; change the underlying rows instead.
 
 ### Project Structure
 ```

--- a/MSYK-OVERVIEW.md
+++ b/MSYK-OVERVIEW.md
@@ -894,13 +894,15 @@ As with workshops, cancellation and refund are two separate steps. Cancelling ne
 
 ### Development Workflow
 
-Every implementation follows **implement → test → verify end to end**. The middle step depends on what changed:
+**Before implementing: ask.** Every non-trivial change starts with clarifying questions to the maintainer — *"ask me any clarifying questions and anything you need from me to do this, we are a team."* Ambiguous scope, two defensible designs, an unclear edge case, or credentials the implementer does not have all get settled up front, not discovered halfway through.
+
+Every implementation then follows **implement → test → verify end to end**. The middle step depends on what changed:
 
 **New functionality**
 1. Implement the feature
 2. Add test files under `tests/` and make them pass
 3. Verify end to end in a real browser via the Playwright MCP server
-4. `npm test` — the suite must stay fully green (**27 suites / 372 tests**)
+4. `npm test` — the suite must stay fully green (**29 suites / 388 tests**)
 5. `npm run typecheck`
 
 **Change to existing functionality** — assume this whenever an existing function, route, query, or schema field is edited, since the existing tests encode the old behaviour
@@ -911,6 +913,23 @@ Every implementation follows **implement → test → verify end to end**. The m
 5. `npm run typecheck`
 
 Step 3 is not optional: a green unit test says the function behaves, only the browser says the feature works. A test is never edited purely to make it pass — establish whether the test or the code is wrong first, and say which.
+
+**Every UI change must be verified at mobile width as well as desktop.** Responsiveness is part of the change, not a follow-up.
+
+**Ask for whatever testing needs.** A test card, a Brivo sandbox credential, a role level 3/4 account, a record seeded into a particular state, or a ruling on the correct behaviour — ask the maintainer rather than skipping the verification, faking the data, or weakening the assertion.
+
+**Browser test accounts** — created by `npx tsx seed.ts` (`NODE_ENV=development`), all with the password `password`:
+
+| Email | Password | Role level | How the level is earned |
+|-------|----------|-----------|--------------------------|
+| `testuser1@gmail.com` | `password` | 1 — **Admin** (`roleUserId: 2`) | Admin role; no orientation or membership |
+| `testuser2@gmail.com` | `password` | 1 | Registered only |
+| `testuser3@gmail.com` | `password` | 1 | Registered only |
+| `testuser4@gmail.com` | `password` | 2 | Passed a past General Orientation |
+| `testuser5@gmail.com` | `password` | 3 | Orientation + active **Makerspace Member** membership |
+| `testuser6@gmail.com` | `password` | 4 | Orientation + active **Drop-In 10 Pass** (`needAdminPermission`) + `allowLevel4` |
+
+None of these levels are written directly. The seed creates the rows that *earn* them — a `UserWorkshop` with `result: "passed"` on an orientation, a `UserMembership` with status `active`, the `allowLevel4` flag — and then derives `roleLevel` from those rows using the same rules as `startRoleLevelSyncCron()`. That cron re-derives the level every 15 seconds, so **editing `roleLevel` by hand does not stick**; change the underlying rows instead.
 
 See [CLAUDE.md](./CLAUDE.md) for the full rules and [tests/README.md](./tests/README.md) for layout and conventions.
 
@@ -972,7 +991,7 @@ The acceptance criteria are organized into three categories:
 | AC16 | Membership Cancellation (Before Cycle End) | Membership status "cancelled"; membership form "cancelled"; user retains access until `nextPaymentDate`; role level unchanged | `tests/models/membership.server.test.ts` |
 | AC17 | Membership Cancellation (After Cycle End) | Membership record deleted; membership form "inactive"; user role level recalculated (Level 2 if orientation completed, else Level 1) | `tests/models/membership.server.test.ts` |
 | AC18 | Membership Resubscription | Cancelled membership status "active"; `nextPaymentDate` recalculated; membership form "active"; role level restored | `tests/models/membership.server.test.ts` |
-| AC19 | Automated Monthly Billing (Cron) | Finds memberships with `nextPaymentDate <= now`; charges monthly memberships with saved payment method; sets non-monthly to "inactive"; updates role levels; sends payment reminders | `tests/models/membership.cron.test.ts` |
+| AC19 | Automated Monthly Billing (Cron) | Registered daily at midnight (`0 0 * * *`); finds memberships with `nextPaymentDate <= now`; charges monthly memberships with saved payment method; sets non-monthly to "inactive"; updates role levels; sends payment reminders; swallows database errors so the job survives to the next night | `tests/models/membership.cron.test.ts` |
 | AC20 | Membership Payment Reminder | Membership due within 24 hours; payment reminder email sent with plan title, next payment date, amount due, payment method reminder | `tests/models/membership.cron.test.ts` |
 | AC21 | Workshop Prerequisites | System checks user completed required workshops; registration blocked if prerequisites not met | `tests/models/workshop.registration.test.ts` |
 | AC22 | Workshop Capacity | System checks available spots; registration blocked if capacity exceeded | `tests/models/workshop.capacity.test.ts` |
@@ -989,6 +1008,9 @@ The acceptance criteria are organized into three categories:
 | - | Admin Workshop Creation | Admin creates new workshop; workshop form validation | `tests/routes/dashboard/addworkshop.test.ts` |
 | - | Admin Equipment Creation | Admin creates new equipment; equipment form validation | `tests/routes/dashboard/addequipment.test.ts` |
 | - | Workshop Registration Cutoff (server-side) | All four workshop URL shapes accepted by the `payment.tsx` loader — single occurrence, single + variation, multi-day, multi-day + variation — redirect away once `Workshop.registrationCutoff` has passed, and still load while registration is open; a cutoff of `0` means no restriction | `tests/routes/dashboard/payment.cutoff.test.ts` |
+| - | Role Level Sync (Cron) | Registered every 15 seconds (`*/15 * * * * *`); recomputes `roleLevel` from passed orientations, memberships in active/ending/cancelled, the plan's `needAdminPermission`, and `allowLevel4`; promotes and demotes, resyncs door access on every correction, writes nothing when the stored level is already right, and swallows database errors | `tests/models/user.rolelevel.test.ts` |
+| - | Workshop Occurrence Status (Interval) | One pass at startup, then every second (`setInterval`, 1000 ms); flips `active` occurrences whose `startDate` has passed to `past`, leaves upcoming ones and an occurrence starting exactly now alone, and rethrows database failures rather than swallowing them | `tests/models/workshop.occurrence-status.test.ts` |
+| - | Background Job Startup | `entry.server.ts` starts all three jobs — membership billing, occurrence status, role level sync — and starts each exactly once per process; a repeat import hits the module cache instead of registering duplicate jobs | `tests/entry.server.test.ts` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,23 @@ npx playwright install chromium   # one-time, only if the browser binary is miss
 
 Then browse `http://localhost:5173`. This is for **interactive verification** — clicking through a flow, checking what a page renders, reading console errors. Automated regression tests belong in `tests/` under Jest; see [Testing Strategy](#testing-strategy).
 
+#### Test accounts
+
+`npx tsx seed.ts` creates six users covering every role level. All of them share the password `password`:
+
+| Email | Password | Role level | How the level is earned |
+|-------|----------|-----------|--------------------------|
+| `testuser1@gmail.com` | `password` | 1 — **Admin** (`roleUserId: 2`) | Admin role; no orientation or membership |
+| `testuser2@gmail.com` | `password` | 1 | Registered only |
+| `testuser3@gmail.com` | `password` | 1 | Registered only |
+| `testuser4@gmail.com` | `password` | 2 | Passed a past General Orientation |
+| `testuser5@gmail.com` | `password` | 3 | Orientation + active **Makerspace Member** membership |
+| `testuser6@gmail.com` | `password` | 4 | Orientation + active **Drop-In 10 Pass** (`needAdminPermission`) + `allowLevel4` |
+
+Use `testuser1` for admin flows, `testuser2`/`testuser3` for a plain registered user, and `testuser4`–`testuser6` for anything gated on role level — equipment booking windows, level 3 scheduling restrictions, level 4 door access.
+
+None of these levels are written directly. The seed creates the rows that *earn* them — a `UserWorkshop` with `result: "passed"` on an orientation, a `UserMembership` with status `active`, the `allowLevel4` flag — and then derives `roleLevel` from those rows using the same rules as `startRoleLevelSyncCron()`. That cron re-derives the level every 15 seconds, so **editing `roleLevel` by hand does not stick**; change the underlying rows instead.
+
 The server writes page snapshots and console logs into `.playwright-mcp/` at the repo root as you drive it. That directory is gitignored — it is session scratch, not something to commit.
 
 ## Environment Variables & Configuration
@@ -435,6 +452,8 @@ Three background jobs are started from `entry.server.ts` (the server process, ru
 | Workshop status update | `startWorkshopOccurrenceStatusUpdate()` | Every 1 second (setInterval) | `app/models/workshop.server.ts` |
 
 The workshop status job runs immediately on startup and then every 1 second, keeping `WorkshopOccurrence.status` up-to-date as time passes.
+
+All three jobs are covered by tests, along with the startup wiring itself: `tests/models/user.rolelevel.test.ts`, `tests/models/membership.cron.test.ts`, `tests/models/workshop.occurrence-status.test.ts`, and `tests/entry.server.test.ts`. The specs replace `node-cron` with a recorder and drive `setInterval` with fake timers, so nothing waits on real time — see [tests/README.md](./tests/README.md#background-jobs).
 
 ### Workshop System Architecture
 
@@ -902,6 +921,25 @@ All models are in `app/models/` (*.server.ts). Some API logic is also in `app/ro
 
 ## Development Patterns
 
+### Mobile Responsiveness
+
+**Every UI change must work at phone width.** This is a requirement of the change, not a follow-up ticket. The app is used on phones in the space, so a layout that only holds together on a desktop viewport is unfinished.
+
+- Use the Tailwind responsive prefixes already used throughout the codebase (`sm:`, `md:`, `lg:`) rather than fixed pixel widths
+- Wide content — tables, booking grids, admin lists — scrolls inside its own `overflow-x-auto` container; the page body must never scroll sideways
+- Keep tap targets and form controls usable at small sizes; stack columns instead of shrinking them past legibility
+- **Verify it.** Resize to a mobile viewport in the Playwright MCP browser and look at the page. Responsive classes are easy to write and easy to get wrong
+
+### Code Comments
+
+Comment where it helps, but keep comments short. A comment must earn its line: clear, concise, relevant, and saying something the code does not already say. One sentence explaining *why* beats a paragraph restating *what*.
+
+- **Do not stack runs of single-line comments** over consecutive statements. A wall of `// do X` / `// then do Y` above every line is noise, and it goes stale the moment the code moves
+- Do not narrate obvious code (`// loop through the users`)
+- Do not leave commentary about the edit itself (`// changed this to fix the bug`) — that belongs in the commit message
+- Do explain non-obvious constraints, workarounds, and rules that live outside the file (a Stripe API quirk, a misspelled `AdminSettings` key, a deliberately disabled sync)
+- Match the comment density of the file you are editing
+
 ### Form Handling
 
 ```typescript
@@ -1011,6 +1049,14 @@ logger.error("Operation failed", { error, userId, context });
 
 ## Testing Strategy
 
+### Before you start: ask
+
+Before implementing anything non-trivial, ask the maintainer your clarifying questions — and say so explicitly:
+
+> Ask me any clarifying questions and anything you need from me to do this. We are a team.
+
+Raise anything that would change what gets built: ambiguous scope, two defensible designs, a missing product decision, an unclear edge case, credentials or access you do not have. Then get on with the parts that do not depend on the answer. A question up front is cheap; an assumption that turns out wrong costs the whole implementation.
+
 ### Required workflow for every implementation
 
 **Implement → test → verify end to end.** All three steps, every time — finishing the code is not finishing the change.
@@ -1041,7 +1087,7 @@ Assume you are here whenever you edit an existing function, route, query, or sch
 
 **Most changes are the second kind.** When unsure, treat it as the second kind.
 
-The suite is currently **fully green — 27 suites, 372 tests** — and every server module is covered. That baseline is what makes step 4 meaningful: a failure after your change is a regression you introduced, not background noise. Do not commit on a red suite without saying so explicitly.
+The suite is currently **fully green — 29 suites, 388 tests** — and every server module is covered. That baseline is what makes step 4 meaningful: a failure after your change is a regression you introduced, not background noise. Do not commit on a red suite without saying so explicitly.
 
 **Rules:**
 
@@ -1050,6 +1096,7 @@ The suite is currently **fully green — 27 suites, 372 tests** — and every se
 - **A suite that reports `0 total` is broken, not passing.** Five equipment suites silently ran zero tests because a Stripe client was constructed at import time with no key. Everything looked green while nothing was checked
 - **A bug fix should carry a test that would have caught it**
 - **Cover the guard, not just the happy path.** Capacity limits, role-level gates, refund windows, upload validation, and "already cancelled" states are where the real defects live
+- **Ask when testing needs something you do not have.** A test or a browser walkthrough often needs input only the maintainer can give — a Stripe test card, a Brivo sandbox credential, a role level 3/4 account, a seeded record, an admin setting flipped, or simply a ruling on what the correct behaviour is. Ask for it. Skipping the step, faking the data, or weakening the assertion to make it pass is worse than being blocked out loud
 
 ### Layout and conventions
 
@@ -1068,13 +1115,16 @@ The suite is currently **fully green — 27 suites, 372 tests** — and every se
 **[tests/README.md](./tests/README.md) is the full reference** for the folder — layout, fixture conventions, the import-ordering rule, and the failure modes that have actually bitten here. Read it before adding or changing a test
 
 **Model tests** (`tests/models/`):
-`access.card-log`, `admin.settings`, `equipment.basic`, `equipment.booking`, `equipment.cancellation`, `equipment.settings`, `equipment.slots`, `issue.server`, `membership.cron`, `membership.server`, `payment.gst`, `payment.refunds`, `profile.volunteer`, `user.rolelevel`, `workshop.basic`, `workshop.cancellation`, `workshop.capacity`, `workshop.move`, `workshop.registration`
+`access.card-log`, `admin.settings`, `equipment.basic`, `equipment.booking`, `equipment.cancellation`, `equipment.settings`, `equipment.slots`, `issue.server`, `membership.cron`, `membership.server`, `payment.gst`, `payment.refunds`, `profile.volunteer`, `user.rolelevel`, `workshop.basic`, `workshop.cancellation`, `workshop.capacity`, `workshop.move`, `workshop.occurrence-status`, `workshop.registration`
 
 **Service tests** (`tests/services/`):
 `access-control-sync.server`, `brivo.server`, `stripe-sync.server`
 
 **Util and config tests:**
 `tests/utils/session.server.test.ts`, `tests/config/access-control.test.ts`
+
+**Boot wiring test:**
+`tests/entry.server.test.ts` — asserts `entry.server.ts` starts all three background jobs, and starts each one only once per process
 
 **Route tests** (`tests/routes/dashboard/`):
 `addequipment.test.ts`, `addworkshop.test.ts`, `payment.cutoff.test.ts`
@@ -1085,6 +1135,7 @@ The suite is currently **fully green — 27 suites, 372 tests** — and every se
 
 **Seed data:**
 - `seed.ts` provides consistent test data; **requires `NODE_ENV=development`** — it logs `Seed aborted` and exits immediately otherwise. Occurrence dates are relative to `now` (e.g. `addDays(now, 7)`) so workshops always appear upcoming regardless of when the seed runs. It truncates and reseeds `RoleUser`, restarting the sequence so `User` = 1 and `Admin` = 2
+- It creates six users, `testuser1@gmail.com` through `testuser6@gmail.com` (password `password`), covering every role level — see [Test accounts](#test-accounts). Levels 2, 3, and 4 come from real seeded rows (a passed orientation, an active membership, `allowLevel4`), and the seed derives `roleLevel` from them with the same rules as `startRoleLevelSyncCron()` rather than assigning it
 
 **Additional scripts** (`test-scripts/`, run with `npx tsx`):
 - `seed-orientation-registrations.ts` — populates any workshop with 20 test users across 5 past sessions with varied results (passed/failed/pending/cancelled) and optional price variations; supports multi-day via `--days=N`. Run: `npx tsx test-scripts/seed-orientation-registrations.ts [workshopId|name] [--days=N]`

--- a/old/editOccurrenceSchema.tsx
+++ b/old/editOccurrenceSchema.tsx
@@ -1,15 +1,15 @@
-import { z } from "zod";
+// import { z } from "zod";
 
-export const editOccurrenceSchema = z.object({
-    startDate: z.coerce.date().refine(
-        (date) => !isNaN(date.getTime()),
-        { message: "Invalid start date" }
-      ),
-      endDate: z.coerce.date().refine(
-        (date) => !isNaN(date.getTime()),
-        { message: "Invalid end date" }
-      ),
-  });
+// export const editOccurrenceSchema = z.object({
+//     startDate: z.coerce.date().refine(
+//         (date) => !isNaN(date.getTime()),
+//         { message: "Invalid start date" }
+//       ),
+//       endDate: z.coerce.date().refine(
+//         (date) => !isNaN(date.getTime()),
+//         { message: "Invalid end date" }
+//       ),
+//   });
   
-  export type OccurrenceEditValues = z.infer<typeof editOccurrenceSchema>;
+//   export type OccurrenceEditValues = z.infer<typeof editOccurrenceSchema>;
   

--- a/old/editoccurrence.tsx
+++ b/old/editoccurrence.tsx
@@ -1,205 +1,205 @@
-import React from "react";
-import { useLoaderData, useActionData } from "react-router-dom";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { editOccurrenceSchema } from "./editOccurrenceSchema";
-import type { OccurrenceEditValues } from "./editOccurrenceSchema";
-import { getWorkshopOccurrence, duplicateOccurrence } from "~/models/workshop.server";
-import {
-  Form,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Button } from "@/components/ui/button";
-import { redirect } from "react-router";
-import GenericFormField from "~/components/ui/Dashboard/GenericFormField";
-import { getRoleUser } from "~/utils/session.server";
-import { logger } from "~/logging/logger";
+// import React from "react";
+// import { useLoaderData, useActionData } from "react-router-dom";
+// import { useForm } from "react-hook-form";
+// import { zodResolver } from "@hookform/resolvers/zod";
+// import { editOccurrenceSchema } from "./editOccurrenceSchema";
+// import type { OccurrenceEditValues } from "./editOccurrenceSchema";
+// import { getWorkshopOccurrence, duplicateOccurrence } from "~/models/workshop.server";
+// import {
+//   Form,
+//   FormItem,
+//   FormLabel,
+//   FormMessage,
+// } from "@/components/ui/form";
+// import { Button } from "@/components/ui/button";
+// import { redirect } from "react-router";
+// import GenericFormField from "~/components/ui/Dashboard/GenericFormField";
+// import { getRoleUser } from "~/utils/session.server";
+// import { logger } from "~/logging/logger";
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  1) Helper: format a Date as "YYYY-MM-DDTHH:mm" for datetime-local
-// ─────────────────────────────────────────────────────────────────────────────
-function formatLocalDatetime(dateInput: Date): string {
-  const date = new Date(dateInput);
-  if (isNaN(date.getTime())) return "";
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-  return `${year}-${month}-${day}T${hours}:${minutes}`;
-}
+// // ─────────────────────────────────────────────────────────────────────────────
+// //  1) Helper: format a Date as "YYYY-MM-DDTHH:mm" for datetime-local
+// // ─────────────────────────────────────────────────────────────────────────────
+// function formatLocalDatetime(dateInput: Date): string {
+//   const date = new Date(dateInput);
+//   if (isNaN(date.getTime())) return "";
+//   const year = date.getFullYear();
+//   const month = String(date.getMonth() + 1).padStart(2, "0");
+//   const day = String(date.getDate()).padStart(2, "0");
+//   const hours = String(date.getHours()).padStart(2, "0");
+//   const minutes = String(date.getMinutes()).padStart(2, "0");
+//   return `${year}-${month}-${day}T${hours}:${minutes}`;
+// }
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  2) Helper: parse a "YYYY-MM-DDTHH:mm" string into a local Date
-// ─────────────────────────────────────────────────────────────────────────────
-function parseDateTimeAsLocal(value: string): Date {
-  if (!value) return new Date(""); // invalid date
-  const [datePart, timePart] = value.split("T");
-  const [year, month, day] = datePart.split("-").map(Number);
-  const [hours, minutes] = timePart.split(":").map(Number);
-  return new Date(year, month - 1, day, hours, minutes);
-}
+// // ─────────────────────────────────────────────────────────────────────────────
+// //  2) Helper: parse a "YYYY-MM-DDTHH:mm" string into a local Date
+// // ─────────────────────────────────────────────────────────────────────────────
+// function parseDateTimeAsLocal(value: string): Date {
+//   if (!value) return new Date(""); // invalid date
+//   const [datePart, timePart] = value.split("T");
+//   const [year, month, day] = datePart.split("-").map(Number);
+//   const [hours, minutes] = timePart.split(":").map(Number);
+//   return new Date(year, month - 1, day, hours, minutes);
+// }
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  3) Loader
-// ─────────────────────────────────────────────────────────────────────────────
-export async function loader({
-  params,
-}: {
-  params: { id: string; occurrenceId: string };
-}) {
-  const workshopId = Number(params.id);
-  const occurrenceId = Number(params.occurrenceId);
+// // ─────────────────────────────────────────────────────────────────────────────
+// //  3) Loader
+// // ─────────────────────────────────────────────────────────────────────────────
+// export async function loader({
+//   params,
+// }: {
+//   params: { id: string; occurrenceId: string };
+// }) {
+//   const workshopId = Number(params.id);
+//   const occurrenceId = Number(params.occurrenceId);
 
-  logger.info("Loading workshop occurrence", {
-    context: "workshop-occurrence-loader",
-    workshopId,
-    occurrenceId,
-  });
+//   logger.info("Loading workshop occurrence", {
+//     context: "workshop-occurrence-loader",
+//     workshopId,
+//     occurrenceId,
+//   });
 
-  const occurrence = await getWorkshopOccurrence(workshopId, occurrenceId);
-  if (!occurrence) {
-    logger.warn("Workshop occurrence not found", {
-      context: "workshop-occurrence-loader",
-      workshopId,
-      occurrenceId,
-    });
-    throw new Response("Occurrence not found", { status: 404 });
-  }
+//   const occurrence = await getWorkshopOccurrence(workshopId, occurrenceId);
+//   if (!occurrence) {
+//     logger.warn("Workshop occurrence not found", {
+//       context: "workshop-occurrence-loader",
+//       workshopId,
+//       occurrenceId,
+//     });
+//     throw new Response("Occurrence not found", { status: 404 });
+//   }
 
-  logger.info("Workshop occurrence loaded successfully", {
-    context: "workshop-occurrence-loader",
-    workshopId,
-    occurrenceId,
-  });
+//   logger.info("Workshop occurrence loaded successfully", {
+//     context: "workshop-occurrence-loader",
+//     workshopId,
+//     occurrenceId,
+//   });
 
-  return { workshopId, occurrenceId, occurrence };
-}
+//   return { workshopId, occurrenceId, occurrence };
+// }
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  4) Action: parse the string values, shift them to UTC if desired
-// ─────────────────────────────────────────────────────────────────────────────
-export async function action({
-  request,
-  params,
-}: {
-  request: Request;
-  params: { id: string; occurrenceId: string };
-}) {
-  const roleUser = await getRoleUser(request);
-  if (!roleUser || roleUser.roleName.toLowerCase() !== "admin") {
-    logger.warn("Unauthorized duplicateOccurrence action", {
-      url: request.url,
-    });
-    throw new Response("Not Authorized", { status: 419 });
-  }
+// // ─────────────────────────────────────────────────────────────────────────────
+// //  4) Action: parse the string values, shift them to UTC if desired
+// // ─────────────────────────────────────────────────────────────────────────────
+// export async function action({
+//   request,
+//   params,
+// }: {
+//   request: Request;
+//   params: { id: string; occurrenceId: string };
+// }) {
+//   const roleUser = await getRoleUser(request);
+//   if (!roleUser || roleUser.roleName.toLowerCase() !== "admin") {
+//     logger.warn("Unauthorized duplicateOccurrence action", {
+//       url: request.url,
+//     });
+//     throw new Response("Not Authorized", { status: 419 });
+//   }
   
-  const formData = await request.formData();
-  const rawValues = Object.fromEntries(formData.entries()) as Record<string, string>;
+//   const formData = await request.formData();
+//   const rawValues = Object.fromEntries(formData.entries()) as Record<string, string>;
 
-  // Convert the string to a Date
-  const parsedStart = parseDateTimeAsLocal(rawValues.startDate);
-  const parsedEnd = parseDateTimeAsLocal(rawValues.endDate);
+//   // Convert the string to a Date
+//   const parsedStart = parseDateTimeAsLocal(rawValues.startDate);
+//   const parsedEnd = parseDateTimeAsLocal(rawValues.endDate);
 
-  // Validate with zod
-  const parsed = editOccurrenceSchema.safeParse({
-    startDate: parsedStart,
-    endDate: parsedEnd,
-  });
-  if (!parsed.success) {
-    return { errors: parsed.error.flatten().fieldErrors };
-  }
+//   // Validate with zod
+//   const parsed = editOccurrenceSchema.safeParse({
+//     startDate: parsedStart,
+//     endDate: parsedEnd,
+//   });
+//   if (!parsed.success) {
+//     return { errors: parsed.error.flatten().fieldErrors };
+//   }
 
-  // If you need to shift to UTC (or PST), do so here
-  const startOffset = parsedStart.getTimezoneOffset();
-  const startDatePST = new Date(parsedStart.getTime() - startOffset * 60000);
-  const endOffset = parsedEnd.getTimezoneOffset();
-  const endDatePST = new Date(parsedEnd.getTime() - endOffset * 60000);
+//   // If you need to shift to UTC (or PST), do so here
+//   const startOffset = parsedStart.getTimezoneOffset();
+//   const startDatePST = new Date(parsedStart.getTime() - startOffset * 60000);
+//   const endOffset = parsedEnd.getTimezoneOffset();
+//   const endDatePST = new Date(parsedEnd.getTime() - endOffset * 60000);
 
-  const workshopId = Number(params.id);
-  const occurrenceId = Number(params.occurrenceId);
+//   const workshopId = Number(params.id);
+//   const occurrenceId = Number(params.occurrenceId);
 
-  await duplicateOccurrence(workshopId, occurrenceId, {
-    startDate: parsedStart,
-    endDate: parsedEnd,
-    startDatePST,
-    endDatePST,
-  });
+//   await duplicateOccurrence(workshopId, occurrenceId, {
+//     startDate: parsedStart,
+//     endDate: parsedEnd,
+//     startDatePST,
+//     endDatePST,
+//   });
 
-  logger.info("Successfully duplicated occurrence", {
-    url: request.url,
-  });
+//   logger.info("Successfully duplicated occurrence", {
+//     url: request.url,
+//   });
 
-  return redirect(`/dashboard/workshops/${workshopId}`);
-}
+//   return redirect(`/dashboard/workshops/${workshopId}`);
+// }
 
-// ─────────────────────────────────────────────────────────────────────────────
-//  5) EditOccurrence Component
-// ─────────────────────────────────────────────────────────────────────────────
-export default function EditOccurrence() {
-  const { workshopId, occurrence, occurrenceId } = useLoaderData() as {
-    workshopId: number;
-    occurrenceId: number;
-    occurrence: { startDate: Date; endDate: Date };
-  };
-  const actionData = useActionData<{ errors?: Record<string, string[]> }>();
+// // ─────────────────────────────────────────────────────────────────────────────
+// //  5) EditOccurrence Component
+// // ─────────────────────────────────────────────────────────────────────────────
+// export default function EditOccurrence() {
+//   const { workshopId, occurrence, occurrenceId } = useLoaderData() as {
+//     workshopId: number;
+//     occurrenceId: number;
+//     occurrence: { startDate: Date; endDate: Date };
+//   };
+//   const actionData = useActionData<{ errors?: Record<string, string[]> }>();
 
-  // Use default values as Date objects (matching your schema)
-  const form = useForm<OccurrenceEditValues>({
-    resolver: zodResolver(editOccurrenceSchema),
-    defaultValues: {
-      startDate: occurrence.startDate,
-      endDate: occurrence.endDate,
-    },
-  });
+//   // Use default values as Date objects (matching your schema)
+//   const form = useForm<OccurrenceEditValues>({
+//     resolver: zodResolver(editOccurrenceSchema),
+//     defaultValues: {
+//       startDate: occurrence.startDate,
+//       endDate: occurrence.endDate,
+//     },
+//   });
 
-  return (
-    <div className="max-w-4xl mx-auto p-8">
-      <h1 className="text-2xl font-bold mb-8 text-center">
-        Offer New Workshop Date
-      </h1>
+//   return (
+//     <div className="max-w-4xl mx-auto p-8">
+//       <h1 className="text-2xl font-bold mb-8 text-center">
+//         Offer New Workshop Date
+//       </h1>
 
-      {actionData?.errors && Object.keys(actionData.errors).length > 0 && (
-        <div className="mb-8 text-sm text-red-500 bg-red-100 border-red-400 rounded p-2">
-          There are some errors in your form. Please review the highlighted fields below.
-        </div>
-      )}
+//       {actionData?.errors && Object.keys(actionData.errors).length > 0 && (
+//         <div className="mb-8 text-sm text-red-500 bg-red-100 border-red-400 rounded p-2">
+//           There are some errors in your form. Please review the highlighted fields below.
+//         </div>
+//       )}
 
-      <Form {...form}>
-        <form method="post" className="space-y-4">
-          {/* Start Date Field */}
-          <GenericFormField
-            control={form.control}
-            name="startDate"
-            label="Start Date"
-            required
-            type="datetime-local"
-            error={actionData?.errors?.startDate}
-          />
+//       <Form {...form}>
+//         <form method="post" className="space-y-4">
+//           {/* Start Date Field */}
+//           <GenericFormField
+//             control={form.control}
+//             name="startDate"
+//             label="Start Date"
+//             required
+//             type="datetime-local"
+//             error={actionData?.errors?.startDate}
+//           />
 
-          {/* End Date Field */}
-          <GenericFormField
-            control={form.control}
-            name="endDate"
-            label="End Date"
-            required
-            type="datetime-local"
-            error={actionData?.errors?.endDate}
-          />
+//           {/* End Date Field */}
+//           <GenericFormField
+//             control={form.control}
+//             name="endDate"
+//             label="End Date"
+//             required
+//             type="datetime-local"
+//             error={actionData?.errors?.endDate}
+//           />
 
-          {/* Submit Button */}
-          <div className="flex justify-center">
-            <Button
-              type="submit"
-              className="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded-md shadow transition text-sm"
-            >
-              Offer Again
-            </Button>
-          </div>
-        </form>
-      </Form>
-    </div>
-  );
-}
+//           {/* Submit Button */}
+//           <div className="flex justify-center">
+//             <Button
+//               type="submit"
+//               className="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded-md shadow transition text-sm"
+//             >
+//               Offer Again
+//             </Button>
+//           </div>
+//         </form>
+//       </Form>
+//     </div>
+//   );
+// }

--- a/old/webhooks.server.ts
+++ b/old/webhooks.server.ts
@@ -1,56 +1,56 @@
-import Stripe from "stripe";
-import { db } from "../app/utils/db.server";
-import { json } from "react-router";
+// import Stripe from "stripe";
+// import { db } from "../app/utils/db.server";
+// import { json } from "react-router";
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
-  apiVersion: "2023-10-16",
-});
+// const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+//   apiVersion: "2023-10-16",
+// });
 
-export async function loader({ request }) {
-  const sig = request.headers.get("stripe-signature");
+// export async function loader({ request }) {
+//   const sig = request.headers.get("stripe-signature");
 
-  if (!sig) {
-    return json({ error: "No signature found" }, { status: 400 });
-  }
+//   if (!sig) {
+//     return json({ error: "No signature found" }, { status: 400 });
+//   }
 
-  let event;
-  try {
-    const rawBody = await request.text();
-    event = stripe.webhooks.constructEvent(
-      rawBody,
-      sig,
-      process.env.STRIPE_WEBHOOK_SECRET as string
-    );
-  } catch (err) {
-    console.error("Webhook signature verification failed.", err);
-    return json({ error: "Invalid signature" }, { status: 400 });
-  }
+//   let event;
+//   try {
+//     const rawBody = await request.text();
+//     event = stripe.webhooks.constructEvent(
+//       rawBody,
+//       sig,
+//       process.env.STRIPE_WEBHOOK_SECRET as string
+//     );
+//   } catch (err) {
+//     console.error("Webhook signature verification failed.", err);
+//     return json({ error: "Invalid signature" }, { status: 400 });
+//   }
 
-  if (event.type === "checkout.session.completed") {
-    const session = event.data.object;
-    const userId = parseInt(session.metadata?.userId || "0");
-    const occurrenceId = parseInt(session.metadata?.occurrenceId || "0");
+//   if (event.type === "checkout.session.completed") {
+//     const session = event.data.object;
+//     const userId = parseInt(session.metadata?.userId || "0");
+//     const occurrenceId = parseInt(session.metadata?.occurrenceId || "0");
 
-    if (!userId || !occurrenceId) {
-      console.error("Invalid metadata in Stripe session.");
-      return json({ error: "Invalid metadata" }, { status: 400 });
-    }
+//     if (!userId || !occurrenceId) {
+//       console.error("Invalid metadata in Stripe session.");
+//       return json({ error: "Invalid metadata" }, { status: 400 });
+//     }
 
-    try {
-      // Confirm registration
-      await db.userWorkshop.create({
-        data: {
-          userId,
-          workshopId: occurrenceId,
-          occurrenceId,
-        },
-      });
+//     try {
+//       // Confirm registration
+//       await db.userWorkshop.create({
+//         data: {
+//           userId,
+//           workshopId: occurrenceId,
+//           occurrenceId,
+//         },
+//       });
 
-      console.log("Registration successful for:", userId, occurrenceId);
-    } catch (error) {
-      console.error("Database error:", error);
-    }
-  }
+//       console.log("Registration successful for:", userId, occurrenceId);
+//     } catch (error) {
+//       console.error("Database error:", error);
+//     }
+//   }
 
-  return json({ received: true });
-}
+//   return json({ received: true });
+// }

--- a/seed.ts
+++ b/seed.ts
@@ -87,6 +87,58 @@ async function main() {
         operationsPolicy: true,
         waiverSignature: "EncryptedWaiverPlaceholder3",
       },
+      // testuser4/5/6 reach role level 2/3/4 through the orientation and membership
+      // rows created further down — roleLevel is left at its default and derived, never set here.
+      {
+        email: "testuser4@gmail.com",
+        password: hashedPassword,
+        firstName: "Test4",
+        lastName: "User4",
+        phone: "4455667788",
+        dateOfBirth: "1992-04-11",
+        emergencyContactName: "Clark Kent",
+        emergencyContactPhone: "5552233445",
+        emergencyContactEmail: "emergency4@example.com",
+        mediaConsent: true,
+        dataPrivacy: true,
+        communityGuidelines: true,
+        operationsPolicy: true,
+        waiverSignature: "EncryptedWaiverPlaceholder4",
+      },
+      {
+        email: "testuser5@gmail.com",
+        password: hashedPassword,
+        firstName: "Test5",
+        lastName: "User5",
+        phone: "5566778899",
+        dateOfBirth: "1985-09-27",
+        emergencyContactName: "Diana Prince",
+        emergencyContactPhone: "5553344556",
+        emergencyContactEmail: "emergency5@example.com",
+        mediaConsent: true,
+        dataPrivacy: true,
+        communityGuidelines: true,
+        operationsPolicy: true,
+        waiverSignature: "EncryptedWaiverPlaceholder5",
+      },
+      {
+        email: "testuser6@gmail.com",
+        password: hashedPassword,
+        firstName: "Test6",
+        lastName: "User6",
+        phone: "6677889900",
+        dateOfBirth: "1998-02-14",
+        emergencyContactName: "Barry Allen",
+        emergencyContactPhone: "5554455667",
+        emergencyContactEmail: "emergency6@example.com",
+        mediaConsent: true,
+        dataPrivacy: true,
+        communityGuidelines: true,
+        operationsPolicy: true,
+        waiverSignature: "EncryptedWaiverPlaceholder6",
+        // Admin-granted flag; level 4 also requires an active needAdminPermission plan.
+        allowLevel4: true,
+      },
     ],
   });
 
@@ -372,6 +424,12 @@ async function main() {
       startDate: addDays(now, -30),
       endDate: addDays(now, -30),
     },
+    // General Orientation — past session the level 2/3/4 accounts passed
+    {
+      workshopId: 4,
+      startDate: addDays(now, -21),
+      endDate: addDays(now, -21),
+    },
     {
       workshopId: 2,
       startDate: addDays(now, -14),
@@ -555,6 +613,125 @@ async function main() {
       },
     ],
   });
+  // Role level 2/3/4 test accounts.
+  //
+  // Nothing here writes a role level directly. It writes the rows that *earn* one — a passed
+  // orientation, an active membership, an admin-permission plan — and then derives roleLevel
+  // from those rows using the same rules as startRoleLevelSyncCron() in
+  // app/models/user.server.ts, which is the source of truth and will re-derive it every 15s:
+  //   level 2 = passed orientation
+  //   level 3 = level 2 + a membership in active/ending/cancelled
+  //   level 4 = level 3 + that plan needs admin permission + the user's allowLevel4 flag
+  const pastOrientation = await prisma.workshopOccurrence.findFirstOrThrow({
+    where: {
+      startDate: { lt: now },
+      workshop: { type: { equals: "orientation", mode: "insensitive" } },
+    },
+    select: { id: true, workshopId: true },
+  });
+
+  const standardPlan = await prisma.membershipPlan.findFirstOrThrow({
+    where: { needAdminPermission: false },
+  });
+  const adminPermissionPlan = await prisma.membershipPlan.findFirstOrThrow({
+    where: { needAdminPermission: true },
+  });
+
+  const levelledEmails = [
+    "testuser4@gmail.com",
+    "testuser5@gmail.com",
+    "testuser6@gmail.com",
+  ];
+  const levelledUsers = await prisma.user.findMany({
+    where: { email: { in: levelledEmails } },
+    select: { id: true, email: true },
+  });
+  const userIdByEmail = new Map(levelledUsers.map((u) => [u.email, u.id]));
+  const userId = (email: string) => {
+    const id = userIdByEmail.get(email);
+    if (!id) throw new Error(`Seed error: ${email} was not created`);
+    return id;
+  };
+
+  // All three passed the same past orientation, which is what clears the level 2 bar.
+  await prisma.userWorkshop.createMany({
+    data: levelledEmails.map((email) => ({
+      userId: userId(email),
+      workshopId: pastOrientation.workshopId,
+      occurrenceId: pastOrientation.id,
+      result: "passed",
+      date: addDays(now, -21),
+    })),
+  });
+
+  await prisma.userMembership.createMany({
+    data: [
+      // Level 3: active membership on a plan that does not need admin permission.
+      {
+        userId: userId("testuser5@gmail.com"),
+        membershipPlanId: standardPlan.id,
+        nextPaymentDate: addDays(now, 30),
+        status: "active",
+      },
+      // Level 4: active membership on the needAdminPermission plan, paired with allowLevel4.
+      {
+        userId: userId("testuser6@gmail.com"),
+        membershipPlanId: adminPermissionPlan.id,
+        nextPaymentDate: addDays(now, 30),
+        status: "active",
+      },
+    ],
+  });
+
+  // Derive roleLevel from what is now in the database, so a freshly seeded DB is already
+  // correct before the app (and its sync cron) starts. Mirrors startRoleLevelSyncCron().
+  const seededUsers = await prisma.user.findMany({
+    select: {
+      id: true,
+      email: true,
+      allowLevel4: true,
+      userWorkshops: {
+        where: {
+          result: { equals: "passed", mode: "insensitive" },
+          workshop: { type: { equals: "orientation", mode: "insensitive" } },
+        },
+        select: { id: true },
+      },
+      userMemberships: {
+        where: { status: { in: ["active", "ending", "cancelled"] } },
+        select: { membershipPlan: { select: { needAdminPermission: true } } },
+      },
+    },
+  });
+
+  for (const user of seededUsers) {
+    const hasCompletedOrientation = user.userWorkshops.length > 0;
+    const hasActiveMembership = user.userMemberships.length > 0;
+    const hasAdminPermissionPlan = user.userMemberships.some(
+      (m) => m.membershipPlan.needAdminPermission,
+    );
+
+    let correctLevel = 1;
+    if (
+      hasCompletedOrientation &&
+      hasActiveMembership &&
+      hasAdminPermissionPlan &&
+      user.allowLevel4
+    ) {
+      correctLevel = 4;
+    } else if (hasCompletedOrientation && hasActiveMembership) {
+      correctLevel = 3;
+    } else if (hasCompletedOrientation) {
+      correctLevel = 2;
+    }
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { roleLevel: correctLevel },
+    });
+    console.log(`Seeded ${user.email} at role level ${correctLevel}`);
+  }
+
   await prisma.equipment.createMany({
     data: [
       {

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,7 @@
 
 Jest test suite for the MSYK Membership Management System.
 
-**Current state: 27 suites, 372 tests, all passing.** Every server module under `app/models/`, `app/services/`, `app/utils/session.server.ts`, and `app/config/` has coverage. That green baseline is what makes a failure meaningful — if the suite goes red after your change, you caused it.
+**Current state: 29 suites, 388 tests, all passing.** Every server module under `app/models/`, `app/services/`, `app/utils/session.server.ts`, and `app/config/` has coverage. That green baseline is what makes a failure meaningful — if the suite goes red after your change, you caused it.
 
 ```bash
 npm test                                      # everything
@@ -27,6 +27,20 @@ Every implementation follows **implement → test → verify end to end**. Which
 
 Most changes are the right-hand column. When in doubt, assume you are. Full rules live in [CLAUDE.md](../CLAUDE.md); the reader-facing version is in [README.md](../README.md#testing-strategy).
 
+**Step 0 is asking.** Before implementing, put the clarifying questions to the maintainer — *"ask me any clarifying questions and anything you need from me to do this, we are a team"* runs in both directions. Scope, expected behaviour at the edges, which of two designs: settle it before writing the test that encodes it.
+
+### Ask for what you need to test
+
+Testing is where an agent most often gets quietly stuck, and where staying stuck does the most damage. If you cannot finish step 2 or step 3 without something only the maintainer can provide — **ask for it**:
+
+- A Stripe test card, a Brivo sandbox credential, a Google OAuth test client
+- A user at role level 3 or 4 (the seed has none, and the sync cron reverts a hand-edited `roleLevel` within 15s)
+- A seeded workshop, membership, or booking in a specific state
+- An admin setting flipped, or a `.env` value you do not have
+- A ruling on what the correct behaviour actually *is*, when the existing test and the new code disagree
+
+Asking costs one message. The alternatives — skipping the verification, faking the data, or softening the assertion until it passes — all ship a change nobody checked. Say what you are blocked on and what would unblock you.
+
 ---
 
 ## Layout
@@ -34,6 +48,7 @@ Most changes are the right-hand column. When in doubt, assume you are. Full rule
 ```
 tests/
 ├── README.md                    # this file
+├── entry.server.test.ts         # boot wiring: the three background jobs start, once each
 ├── config/                      # app/config/
 │   └── access-control.test.ts
 ├── models/                      # app/models/
@@ -45,7 +60,7 @@ tests/
 │   ├── payment.{gst,refunds}.test.ts
 │   ├── profile.volunteer.test.ts
 │   ├── user.rolelevel.test.ts
-│   └── workshop.{basic,cancellation,capacity,move,registration}.test.ts
+│   └── workshop.{basic,cancellation,capacity,move,occurrence-status,registration}.test.ts
 ├── services/                    # app/services/
 │   ├── access-control-sync.server.test.ts
 │   ├── brivo.server.test.ts
@@ -69,6 +84,26 @@ tests/
 ```
 
 Specs mirror the source tree. A file with more than roughly 20 tests is split by concern (`equipment.booking` vs `equipment.slots`) rather than growing without bound.
+
+---
+
+## Background jobs
+
+Three jobs run for the life of the server process, all started from `entry.server.ts`. Each has its own spec, and the wiring that starts them has one too:
+
+| Job | Cadence | Started by | Spec |
+|-----|---------|-----------|------|
+| Role level sync | every 15s (`*/15 * * * * *`, node-cron) | `startRoleLevelSyncCron()` | `models/user.rolelevel.test.ts` |
+| Membership billing | daily at midnight (`0 0 * * *`, node-cron) | `startMonthlyMembershipCheck()` | `models/membership.cron.test.ts` |
+| Occurrence status | every 1s (`setInterval`) | `startWorkshopOccurrenceStatusUpdate()` | `models/workshop.occurrence-status.test.ts` |
+| — all three start at boot | once per process | `entry.server.ts` | `entry.server.test.ts` |
+
+Testing them means never waiting on real time:
+
+- **node-cron is mocked as a recorder.** `fixtures/user/setup.ts` and `fixtures/membership/setup.ts` replace `cron.schedule` with a mock that stores `{ expression, handler }`, so a spec asserts the expression and then calls the handler directly. Note the difference between the two fixtures: the membership recorder *invokes* the handler as it registers it (the spec awaits `job.execution`), while the user one does not (the spec calls `job.handler()` itself)
+- **`setInterval` uses fake timers.** The occurrence job takes no schedule argument, so the spec asserts `setInterval(fn, 1000)` and drives it with `jest.advanceTimersByTime`, counting `db.workshopOccurrence.findMany` calls as passes. `jest.clearAllTimers()` in `afterEach` stops the interval leaking into the next test
+- **Assert the schedule, not just the work.** A job whose handler is correct but whose expression was changed to `0 0 * * *` from `*/15 * * * * *` is still broken
+- **Failure behaviour differs on purpose, so test what each one actually does.** The role-level and membership jobs catch and log, because a throw would kill a job that has to survive until the next tick. `updateWorkshopOccurrenceStatuses()` rethrows
 
 ---
 
@@ -108,6 +143,25 @@ A fixture has to carry every relation the query `include`s. `cancelWorkshopOccur
 ### Test the guard, not just the happy path
 
 Where the defects actually are: capacity limits, role-level gates, refund windows, upload validation, `already cancelled` states, and "what happens when the third-party integration is not configured".
+
+---
+
+## Browser verification accounts
+
+Step 3 needs a real login. `npx tsx seed.ts` (requires `NODE_ENV=development`) creates six users, all with the password `password`, one for every role level:
+
+| Email | Password | Role level | How the level is earned |
+|-------|----------|-----------|--------------------------|
+| `testuser1@gmail.com` | `password` | 1 — **Admin** (`roleUserId: 2`) | Admin role; no orientation or membership |
+| `testuser2@gmail.com` | `password` | 1 | Registered only |
+| `testuser3@gmail.com` | `password` | 1 | Registered only |
+| `testuser4@gmail.com` | `password` | 2 | Passed a past General Orientation |
+| `testuser5@gmail.com` | `password` | 3 | Orientation + active **Makerspace Member** membership |
+| `testuser6@gmail.com` | `password` | 4 | Orientation + active **Drop-In 10 Pass** (`needAdminPermission`) + `allowLevel4` |
+
+Use `testuser1` for admin flows (settings, user management, workshop and equipment administration), `testuser2`/`testuser3` for a plain registered user — including the check that a non-admin is redirected away from admin routes — and `testuser4`–`testuser6` for anything gated on role level.
+
+None of these levels are written directly. The seed creates the rows that *earn* them — a `UserWorkshop` with `result: "passed"` on an orientation, a `UserMembership` with status `active`, the `allowLevel4` flag — and then derives `roleLevel` from those rows using the same rules as `startRoleLevelSyncCron()`. That cron re-derives the level every 15 seconds, so **editing `roleLevel` by hand does not stick**; change the underlying rows instead.
 
 ---
 

--- a/tests/entry.server.test.ts
+++ b/tests/entry.server.test.ts
@@ -1,0 +1,65 @@
+// entry.server.ts is the only place the three background jobs are started. Nothing else
+// in the suite notices if one of those calls is dropped — the models still behave, the
+// jobs simply never run in production. This suite guards the wiring itself.
+
+const mockStartMonthlyMembershipCheck = jest.fn();
+const mockStartWorkshopOccurrenceStatusUpdate = jest.fn();
+const mockStartRoleLevelSyncCron = jest.fn();
+
+jest.mock("~/models/membership.server", () => ({
+  startMonthlyMembershipCheck: mockStartMonthlyMembershipCheck,
+}));
+jest.mock("~/models/workshop.server", () => ({
+  startWorkshopOccurrenceStatusUpdate: mockStartWorkshopOccurrenceStatusUpdate,
+}));
+jest.mock("~/models/user.server", () => ({
+  startRoleLevelSyncCron: mockStartRoleLevelSyncCron,
+}));
+
+describe("entry.server - background job startup", () => {
+  let logSpy: jest.SpyInstance;
+
+  /** Importing the entry point is what starts the jobs. */
+  const boot = () => require("../entry.server");
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockStartMonthlyMembershipCheck.mockClear();
+    mockStartWorkshopOccurrenceStatusUpdate.mockClear();
+    mockStartRoleLevelSyncCron.mockClear();
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("starts the membership billing cron", () => {
+    boot();
+
+    expect(mockStartMonthlyMembershipCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts the workshop occurrence status job", () => {
+    boot();
+
+    expect(mockStartWorkshopOccurrenceStatusUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts the role level sync cron", () => {
+    boot();
+
+    expect(mockStartRoleLevelSyncCron).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers each job once per process, not once per import", () => {
+    // A second import must hit the module cache — re-running the file would register
+    // duplicate cron jobs and double-charge memberships at midnight.
+    boot();
+    boot();
+
+    expect(mockStartMonthlyMembershipCheck).toHaveBeenCalledTimes(1);
+    expect(mockStartWorkshopOccurrenceStatusUpdate).toHaveBeenCalledTimes(1);
+    expect(mockStartRoleLevelSyncCron).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/models/membership.cron.test.ts
+++ b/tests/models/membership.cron.test.ts
@@ -51,6 +51,27 @@ describe("membership.server - cron", () => {
     jest.useRealTimers();
   });
 
+  it("registers on the daily midnight schedule", async () => {
+    db.userMembership.findMany.mockResolvedValue([]);
+
+    await runCron();
+
+    expect(mocks.mockCronSchedule).toHaveBeenCalledWith(
+      "0 0 * * *",
+      expect.any(Function)
+    );
+  });
+
+  it("survives a database failure so the daily job keeps running", async () => {
+    db.userMembership.findMany.mockRejectedValue(new Error("db down"));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(runCron()).resolves.not.toThrow();
+
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
   it("charges active monthly memberships with saved payment info and advances nextPaymentDate", async () => {
     const plan = createMockPlan({ id: 1, price: 100 });
     const membership = createMockMembership({

--- a/tests/models/workshop.occurrence-status.test.ts
+++ b/tests/models/workshop.occurrence-status.test.ts
@@ -1,0 +1,159 @@
+import "tests/fixtures/workshop/setup";
+
+import { getWorkshopMocks } from "tests/fixtures/workshop/setup";
+import { clearAllMocks } from "tests/helpers/test-utils";
+import {
+  updateWorkshopOccurrenceStatuses,
+  startWorkshopOccurrenceStatusUpdate,
+} from "~/models/workshop.server";
+
+describe("workshop.server - occurrence status background job", () => {
+  const now = new Date("2025-06-15T12:00:00Z");
+
+  let db: ReturnType<typeof getWorkshopMocks>["db"];
+  let logSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  /** The query selects only id and startDate, so the fixture carries only those. */
+  const activeOccurrence = (id: number, startDate: string) => ({
+    id,
+    startDate: new Date(startDate),
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(now);
+    clearAllMocks();
+    db = getWorkshopMocks().db;
+    db.workshopOccurrence.findMany.mockResolvedValue([]);
+    db.workshopOccurrence.updateMany.mockResolvedValue({ count: 0 });
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  describe("updateWorkshopOccurrenceStatuses", () => {
+    it("only considers occurrences that are still active", async () => {
+      await updateWorkshopOccurrenceStatuses();
+
+      expect(db.workshopOccurrence.findMany).toHaveBeenCalledWith({
+        where: { status: "active" },
+        select: { id: true, startDate: true },
+      });
+    });
+
+    it("flips started occurrences to past and reports how many moved", async () => {
+      db.workshopOccurrence.findMany.mockResolvedValue([
+        activeOccurrence(1, "2025-06-15T10:00:00Z"),
+        activeOccurrence(2, "2025-06-14T09:00:00Z"),
+      ]);
+      db.workshopOccurrence.updateMany.mockResolvedValue({ count: 2 });
+
+      const result = await updateWorkshopOccurrenceStatuses();
+
+      expect(db.workshopOccurrence.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: [1, 2] } },
+        data: { status: "past" },
+      });
+      expect(result).toEqual({ updated: 2 });
+    });
+
+    it("writes nothing when every active occurrence is still upcoming", async () => {
+      db.workshopOccurrence.findMany.mockResolvedValue([
+        activeOccurrence(1, "2025-06-15T13:00:00Z"),
+        activeOccurrence(2, "2025-07-01T10:00:00Z"),
+      ]);
+
+      const result = await updateWorkshopOccurrenceStatuses();
+
+      expect(db.workshopOccurrence.updateMany).not.toHaveBeenCalled();
+      expect(result).toEqual({ updated: 0 });
+    });
+
+    it("updates only the started occurrences in a mixed batch", async () => {
+      db.workshopOccurrence.findMany.mockResolvedValue([
+        activeOccurrence(1, "2025-06-14T10:00:00Z"), // started yesterday
+        activeOccurrence(2, "2025-06-15T14:00:00Z"), // starts in two hours
+        activeOccurrence(3, "2025-06-15T11:59:59Z"), // started a second ago
+      ]);
+      db.workshopOccurrence.updateMany.mockResolvedValue({ count: 2 });
+
+      await updateWorkshopOccurrenceStatuses();
+
+      expect(db.workshopOccurrence.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: [1, 3] } },
+        data: { status: "past" },
+      });
+    });
+
+    it("leaves an occurrence starting exactly now alone", async () => {
+      // The comparison is strictly `startDate < now`, so a workshop starting this
+      // instant stays active and is picked up on the next tick.
+      db.workshopOccurrence.findMany.mockResolvedValue([
+        activeOccurrence(1, "2025-06-15T12:00:00Z"),
+      ]);
+
+      const result = await updateWorkshopOccurrenceStatuses();
+
+      expect(db.workshopOccurrence.updateMany).not.toHaveBeenCalled();
+      expect(result).toEqual({ updated: 0 });
+    });
+
+    it("rethrows a database failure instead of swallowing it", async () => {
+      db.workshopOccurrence.findMany.mockRejectedValue(new Error("db down"));
+
+      await expect(updateWorkshopOccurrenceStatuses()).rejects.toThrow(
+        "db down"
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Error updating workshop occurrence statuses")
+      );
+    });
+  });
+
+  describe("startWorkshopOccurrenceStatusUpdate", () => {
+    it("runs one pass immediately so stale statuses are fixed at boot", () => {
+      startWorkshopOccurrenceStatusUpdate();
+
+      expect(db.workshopOccurrence.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps running once per second", () => {
+      startWorkshopOccurrenceStatusUpdate();
+      expect(db.workshopOccurrence.findMany).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(1000);
+      expect(db.workshopOccurrence.findMany).toHaveBeenCalledTimes(2);
+
+      jest.advanceTimersByTime(3000);
+      expect(db.workshopOccurrence.findMany).toHaveBeenCalledTimes(5);
+    });
+
+    it("schedules on a 1 second interval", () => {
+      const setIntervalSpy = jest.spyOn(global, "setInterval");
+
+      startWorkshopOccurrenceStatusUpdate();
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 1000);
+      setIntervalSpy.mockRestore();
+    });
+
+    it("keeps ticking after a pass that updates nothing", () => {
+      db.workshopOccurrence.findMany.mockResolvedValue([
+        activeOccurrence(1, "2025-07-01T10:00:00Z"),
+      ]);
+
+      startWorkshopOccurrenceStatusUpdate();
+      jest.advanceTimersByTime(2000);
+
+      expect(db.workshopOccurrence.findMany).toHaveBeenCalledTimes(3);
+      expect(db.workshopOccurrence.updateMany).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two gaps closed, plus the standing rules that led to them.

**Seeded accounts stopped at role level 1.** `seed.ts` created three users, all level 1, so any flow gated on role level — equipment booking windows, the level 3 scheduling restrictions, level 4 door access — could not be exercised without hand-building the data. Editing `User.roleLevel` directly did not work either: `startRoleLevelSyncCron()` re-derives it from real state every 15 seconds and reverts the edit. The seed now creates a level 2, level 3, and level 4 account by writing the rows that *earn* those levels.

**The occurrence-status job had no tests.** Of the three background jobs, only the role-level cron and the membership billing cron were covered. The 1-second `setInterval` job that flips `WorkshopOccurrence.status` from `active` to `past` had none, and nothing at all guarded `entry.server.ts` — deleting a `start*()` call from it left every existing test green while the job silently never ran.

## Seeded role level accounts

`npx tsx seed.ts` now creates six users instead of three, all with the password `password`:

| Email | Role level | Earned by |
|-------|-----------|-----------|
| `testuser1@gmail.com` | 1 — Admin (`roleUserId: 2`) | admin role, no orientation or membership |
| `testuser2@gmail.com` | 1 | registered only |
| `testuser3@gmail.com` | 1 | registered only |
| `testuser4@gmail.com` | 2 | passed a past General Orientation |
| `testuser5@gmail.com` | 3 | + active **Makerspace Member** membership |
| `testuser6@gmail.com` | 4 | + active **Drop-In 10 Pass** (`needAdminPermission`) + `allowLevel4` |

**No level is hardcoded.** The seed writes a `UserWorkshop` with `result: "passed"` against a workshop of `type: "orientation"`, a `UserMembership` with status `active`, and the `allowLevel4` flag — then derives `roleLevel` from those rows using the same query and branch order as `startRoleLevelSyncCron()` in `app/models/user.server.ts`. Deriving rather than asserting means a freshly seeded database is correct before the server starts, and the cron finds nothing to correct once it does.

Supporting data: one past `General Orientation` occurrence (`addDays(now, -21)`), which the existing mapper marks `status: "past"` automatically.

## Background job tests

| Job | Cadence | Spec |
|-----|---------|------|
| Role level sync | every 15s (`*/15 * * * * *`) | `tests/models/user.rolelevel.test.ts` (existing) |
| Membership billing | daily at midnight (`0 0 * * *`) | `tests/models/membership.cron.test.ts` (extended) |
| Occurrence status | every 1s (`setInterval`) | `tests/models/workshop.occurrence-status.test.ts` (new) |
| All three start at boot | once per process | `tests/entry.server.test.ts` (new) |

- **`tests/models/workshop.occurrence-status.test.ts`** — 10 tests over `updateWorkshopOccurrenceStatuses()` and `startWorkshopOccurrenceStatusUpdate()`: the query shape (`where: { status: "active" }`), flipping started occurrences with the right IDs, the empty-batch early return, `setInterval(fn, 1000)`, the immediate pass at boot, and continued ticking
- **`tests/entry.server.test.ts`** — asserts `entry.server.ts` calls all three `start*()` functions, and that a repeat import hits the module cache rather than registering duplicate jobs
- **`tests/models/membership.cron.test.ts`** — adds the two assertions the suite was missing: that the job registers on `0 0 * * *`, and that a database failure is swallowed rather than killing the job

Neither new spec waits on real time. `node-cron` is already mocked as a recorder in the domain fixtures; the interval job is driven with `jest.advanceTimersByTime`, counting `db.workshopOccurrence.findMany` calls as passes.

Suite goes from **27 suites / 372 tests** to **29 suites / 388 tests**, fully green.

## Edge cases handled

- **An occurrence starting exactly now stays `active`.** The comparison is strictly `startDate < now`, so a workshop starting this instant is picked up on the next tick, not this one — covered by its own test so the boundary cannot drift silently
- **Mixed batches.** Only the started IDs reach `updateMany`; upcoming occurrences in the same result set are excluded
- **No writes when nothing is due.** The function returns `{ updated: 0 }` and issues no `updateMany` at all, rather than an empty no-op write
- **Failure behaviour differs per job, deliberately, and each is tested as-is.** The role-level and membership crons catch and log — a throw would kill a job that has to survive to the next tick. `updateWorkshopOccurrenceStatuses()` rethrows. Worth a reviewer's attention: the `setInterval` callback in `app/models/workshop.server.ts` does not catch, so a sustained database outage produces an unhandled rejection every second. The test documents current behaviour rather than changing it
- **Duplicate job registration.** A second import of `entry.server.ts` must not re-register the midnight billing job — duplicate registration would double-charge memberships
- **Seed ordering.** The level rows are created after the occurrences and membership plans exist, and users are looked up by email rather than by assumed sequence ID
- **Occurrence IDs shift by one** because of the new past orientation occurrence. Nothing in the repo hardcodes an occurrence ID, but local bookmarks to `/dashboard/workshops/*/occurrence/N` will point one row over after a reseed

## Standing rules added to the docs

Four rules that apply to every implementation from here on, added to `CLAUDE.md`, `README.md`, `MSYK-OVERVIEW.md`, `tests/README.md`, and the `.claude` command docs:

- **Ask clarifying questions before implementing.** Scope, competing designs, unclear edge cases, and missing credentials get settled up front rather than assumed
- **Mobile responsiveness is part of every UI change**, verified at phone width in the Playwright MCP browser — not a follow-up ticket
- **Comments must earn their line.** No stacked runs of single-line comments over consecutive statements, no narrating obvious code, no commentary about the edit itself
- **Ask for what testing needs.** A test card, a sandbox credential, a record in a particular state, or a ruling on expected behaviour — asking beats skipping the verification, faking the data, or weakening the assertion

`tests/README.md` also gains a **Background jobs** section documenting the two mocking patterns and the differing failure behaviour, and every doc that cited the suite count was updated.

## Also in this branch

Three earlier commits comment out the unused files under `old/` (`editoccurrence.tsx`, `editOccurrenceSchema.tsx`, `webhooks.server.ts`). These were the source of the three long-standing `npm run typecheck` errors; typecheck is now clean.

## Files changed

- `seed.ts` — three new users, one past orientation occurrence, the earned-level rows, and the derivation pass
- `tests/entry.server.test.ts`, `tests/models/workshop.occurrence-status.test.ts` — new
- `tests/models/membership.cron.test.ts` — schedule and resilience assertions
- `README.md`, `CLAUDE.md`, `MSYK-OVERVIEW.md`, `tests/README.md`, `.claude/README.md`, `.claude/commands/read-docs.md`, `.claude/commands/commit.md` — rules, account reference, cron coverage, counts
- `old/*` — dead code commented out

No Prisma migration; no schema change. A deploy needs no `prisma migrate deploy` for this branch.
